### PR TITLE
Serialization types

### DIFF
--- a/examples/template.html
+++ b/examples/template.html
@@ -8,21 +8,35 @@
     <div id="paper">
     </div>
     <div>
-        <button name="ppt_up" type="button">+</button><button name="ppt_down">-</button><button name="left">&lt;</button><button name="right">&gt;</button><button name="live">live</button></div>
+        <button name="json" type="button">Serialize and Reload</button>
+    </div>
+    <div>
+        <button name="ppt_up" type="button">+</button><button name="ppt_down">-</button><button name="left">&lt;</button><button name="right">&gt;</button><button name="live">live</button>
     </div>
     <div id="monitor">
     </div>
     <script>
-      const circuit = new digitaljs.Circuit(<%= htmlWebpackPlugin.options.test %>);
-      const monitor = new digitaljs.Monitor(circuit);
-      const monitorview = new digitaljs.MonitorView({model: monitor, el: $('#monitor') });
-      const paper = circuit.displayOn($('#paper'));
+      var circuit, monitor, monitorview;
+      const loadCircuit = function (json) {
+        circuit = new digitaljs.Circuit(json);
+        monitor = new digitaljs.Monitor(circuit);
+        monitorview = new digitaljs.MonitorView({model: monitor, el: $('#monitor') });
+        circuit.displayOn($('#paper'));
+        circuit.start();
+      }
+      $('button[name=json]').on('click', (e) => {
+        monitorview.shutdown();
+        circuit.stop();
+        const json = circuit.toJSON();
+        console.log(json);
+        loadCircuit(json);
+      });
       $('button[name=ppt_up]').on('click', (e) => { monitorview.pixelsPerTick *= 2; });
       $('button[name=ppt_down]').on('click', (e) => { monitorview.pixelsPerTick /= 2; });
       $('button[name=left]').on('click', (e) => { monitorview.live = false; monitorview.start -= monitorview._width / monitorview.pixelsPerTick / 4; });
       $('button[name=right]').on('click', (e) => { monitorview.live = false; monitorview.start += monitorview._width / monitorview.pixelsPerTick / 4; });
       $('button[name=live]').on('click', (e) => { monitorview.live = true; });
-      circuit.start();
+      loadCircuit(<%= htmlWebpackPlugin.options.test %>);
     </script>
   </body>
 </html>

--- a/src/cells/base.js
+++ b/src/cells/base.js
@@ -88,7 +88,7 @@ export const Gate = joint.shapes.basic.Generic.define('Gate', {
     getGateParams: function() {
         return _.cloneDeep(_.pick(this.attributes, this.gateParams))
     },
-    gateParams: ['label', 'position', 'celltype', 'propagation']
+    gateParams: ['label', 'position', 'type', 'propagation']
 });
 
 export const GateView = joint.dia.ElementView.extend({

--- a/src/cells/subcircuit.js
+++ b/src/cells/subcircuit.js
@@ -72,7 +72,8 @@ export const Subcircuit = Box.define('Subcircuit', {
         args.attrs['rect.body'] = size;
         args.circuitIOmap = iomap;
         Gate.prototype.constructor.apply(this, arguments);
-    }
+    },
+    gateParams: Box.prototype.gateParams.concat(['celltype'])
 });
 
 export const SubcircuitView = BoxView.extend({

--- a/src/circuit.js
+++ b/src/circuit.js
@@ -155,7 +155,7 @@ export class HeadlessCircuit {
         for (const devid in data.devices) {
             const dev = data.devices[devid];
             if (dev.position) laid_out = true;
-            const cellType = getCellType(dev.celltype);
+            const cellType = (dev.type in cells) ? cells[dev.type] : getCellType(dev.celltype);
             const cellArgs = _.clone(dev);
             cellArgs.id = devid;
             if (cellType == cells.Subcircuit)


### PR DESCRIPTION
As requested in #1, this PR changes the serialization to and the deserialization from json to the cell's class names.

It also keeps backwards compatibility to yosys2digitaljs output by accepting both `type` or `celltype` in this priority order.

Fixes #1.