### PR TITLE
Add fixed mode on paper side

### DIFF
--- a/examples/template.html
+++ b/examples/template.html
@@ -8,6 +8,7 @@
     <div id="paper">
     </div>
     <div>
+        <input name="fixed" type="checkbox">Fixed Mode</input>
         <button name="json" type="button">Serialize and Reload</button>
     </div>
     <div>
@@ -16,12 +17,13 @@
     <div id="monitor">
     </div>
     <script>
-      var circuit, monitor, monitorview;
+      var circuit, monitor, monitorview, paper;
       const loadCircuit = function (json) {
         circuit = new digitaljs.Circuit(json);
         monitor = new digitaljs.Monitor(circuit);
         monitorview = new digitaljs.MonitorView({model: monitor, el: $('#monitor') });
-        circuit.displayOn($('#paper'));
+        paper = circuit.displayOn($('#paper'));
+        paper.fixed($('input[name=fixed]').prop('checked'));
         circuit.start();
       }
       $('button[name=json]').on('click', (e) => {
@@ -31,12 +33,15 @@
         console.log(json);
         loadCircuit(json);
       });
+      $('input[name=fixed]').change(function () {
+        paper.fixed($(this).prop('checked'));
+      });
       $('button[name=ppt_up]').on('click', (e) => { monitorview.pixelsPerTick *= 2; });
       $('button[name=ppt_down]').on('click', (e) => { monitorview.pixelsPerTick /= 2; });
       $('button[name=left]').on('click', (e) => { monitorview.live = false; monitorview.start -= monitorview._width / monitorview.pixelsPerTick / 4; });
       $('button[name=right]').on('click', (e) => { monitorview.live = false; monitorview.start += monitorview._width / monitorview.pixelsPerTick / 4; });
       $('button[name=live]').on('click', (e) => { monitorview.live = true; });
-      loadCircuit(<%= htmlWebpackPlugin.options.test %>);
+      $(window).ready(function () { loadCircuit(<%= htmlWebpackPlugin.options.test %>) });
     </script>
   </body>
 </html>

--- a/examples/template.html
+++ b/examples/template.html
@@ -18,12 +18,24 @@
     </div>
     <script>
       var circuit, monitor, monitorview, paper;
+      var subpapers = {};
+      const fixed = function (fixed) {
+        paper.fixed(fixed);
+        Object.values(subpapers).forEach(p => p.fixed(fixed));
+      }
       const loadCircuit = function (json) {
         circuit = new digitaljs.Circuit(json);
         monitor = new digitaljs.Monitor(circuit);
         monitorview = new digitaljs.MonitorView({model: monitor, el: $('#monitor') });
         paper = circuit.displayOn($('#paper'));
-        paper.fixed($('input[name=fixed]').prop('checked'));
+        fixed($('input[name=fixed]').prop('checked'));
+        circuit.on('new:paper', function(subpaper) {
+          subpaper.fixed($('input[name=fixed]').prop('checked'));
+          subpapers[subpaper.cid] = subpaper;
+        });
+        circuit.on('remove:paper', function(subpaper) {
+          delete subpapers[subpaper.cid];
+        });
         circuit.start();
       }
       $('button[name=json]').on('click', (e) => {
@@ -34,7 +46,7 @@
         loadCircuit(json);
       });
       $('input[name=fixed]').change(function () {
-        paper.fixed($(this).prop('checked'));
+        fixed($(this).prop('checked'));
       });
       $('button[name=ppt_up]').on('click', (e) => { monitorview.pixelsPerTick *= 2; });
       $('button[name=ppt_down]').on('click', (e) => { monitorview.pixelsPerTick /= 2; });

--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,7 @@ export class Circuit extends HeadlessCircuit {
         return this.makePaper(elem, this._graph);
     }
     makePaper(elem, graph, opts) {
+        const circuit = this;
         opts = opts || {};
         const paper = new joint.dia.Paper({
             async: true,
@@ -145,12 +146,12 @@ export class Circuit extends HeadlessCircuit {
                     div.on('dialogclose', function(evt) {
                         paper.remove();
                         div.remove();
+                        circuit.trigger('remove:paper', paper);
                     });
                 }
             });
         });
         paper.fixed = function(fixed) {
-            console.log(this, fixed);
             this.setInteractivity(!fixed);
             this.$el.toggleClass('fixed', fixed);
         };

--- a/src/index.js
+++ b/src/index.js
@@ -149,6 +149,11 @@ export class Circuit extends HeadlessCircuit {
                 }
             });
         });
+        paper.fixed = function(fixed) {
+            console.log(this, fixed);
+            this.setInteractivity(!fixed);
+            this.$el.toggleClass('fixed', fixed);
+        };
         this.trigger('new:paper', paper);
         return paper;
     }

--- a/src/style.css
+++ b/src/style.css
@@ -173,6 +173,19 @@
     stroke: #4B4F6A;
 }
 
+.djs.fixed .joint-link,
+.djs.fixed .joint-element:not(.joint-type-subcircuit):not(.joint-type-numentry):not(.joint-type-numdisplay):not(.joint-type-constant):not(.joint-type-button):not(.joint-type-memory) {
+    pointer-events: none;
+}
+.djs.fixed .joint-element.joint-type-subcircuit,
+.djs.fixed .joint-element.joint-type-numentry,
+.djs.fixed .joint-element.joint-type-numdisplay,
+.djs.fixed .joint-element.joint-type-constant,
+.djs.fixed .joint-element.joint-type-button,
+.djs.fixed .joint-element.joint-type-memory {
+    cursor: default;
+}
+
 
 
 /* .viewport is a <g> node wrapping all diagram elements in the paper */

--- a/src/style.css
+++ b/src/style.css
@@ -173,16 +173,10 @@
     stroke: #4B4F6A;
 }
 
-.djs.fixed .joint-link,
-.djs.fixed .joint-element:not(.joint-type-subcircuit):not(.joint-type-numentry):not(.joint-type-numdisplay):not(.joint-type-constant):not(.joint-type-button):not(.joint-type-memory) {
+.djs.fixed .joint-link {
     pointer-events: none;
 }
-.djs.fixed .joint-element.joint-type-subcircuit,
-.djs.fixed .joint-element.joint-type-numentry,
-.djs.fixed .joint-element.joint-type-numdisplay,
-.djs.fixed .joint-element.joint-type-constant,
-.djs.fixed .joint-element.joint-type-button,
-.djs.fixed .joint-element.joint-type-memory {
+.djs.fixed .joint-element {
     cursor: default;
 }
 
@@ -218,10 +212,10 @@ path:not([d]) {
 
 
 /* magnet is an element that can be either source or a target of a link */
-[magnet=true]:not(.joint-element) {
+.djs:not(.fixed) [magnet=true]:not(.joint-element) {
    cursor: crosshair;
 }
-[magnet=true]:not(.joint-element):hover {
+.djs:not(.fixed) [magnet=true]:not(.joint-element):hover {
    opacity: .7;
 }
 


### PR DESCRIPTION
As discussed in #4, this PR adds a fixed mode neither gates can be moved nor wires added. The mode can be set by `paper.fixed(boolean)`. You may try it using the "fixed mode" checkbox in the `template.html`.

Currently, the CSS rules feel kind of hacky as I still want to respond to mouseovers on gates where the displayed base (hex, dec etc.) may be changed or on subcircuits and memory to be able to open them in a popup window. Also clicks on inputs should be reacted on. I'm not sure if I even found all of the cases. Perhaps we could add some extra css class to the elements that still should respond to mouse events s.th. the rules would look nicer.

Also fixed mode is still not applied on subcircuit papers, for this to work the circuit itself should be aware of the fixed mode.

Do you have some thoughts on this?

Fixes #4.