### PR TITLE
Decouple subwindow handling from core logic

### DIFF
--- a/examples/fsm.json
+++ b/examples/fsm.json
@@ -1,0 +1,343 @@
+{
+  "devices": {
+    "dev0": {
+      "celltype": "$clock",
+      "label": "clk",
+      "net": "clk",
+      "order": 0,
+      "bits": 1,
+      "propagation": 100
+    },
+    "dev1": {
+      "celltype": "$button",
+      "label": "rst",
+      "net": "rst",
+      "order": 1,
+      "bits": 1
+    },
+    "dev2": {
+      "celltype": "$button",
+      "label": "a",
+      "net": "a",
+      "order": 2,
+      "bits": 1
+    },
+    "dev3": {
+      "celltype": "$lamp",
+      "label": "b",
+      "net": "b",
+      "order": 3,
+      "bits": 1
+    },
+    "dev4": {
+      "label": "$fsm$\\state$21",
+      "celltype": "$fsm",
+      "polarity": {
+        "clock": true,
+        "arst": true
+      },
+      "wirename": "\\state",
+      "bits": {
+        "in": 1,
+        "out": 5
+      },
+      "states": 4,
+      "init_state": 2,
+      "trans_table": [
+        {
+          "state_in": 3,
+          "ctrl_in": "x",
+          "state_out": 0,
+          "ctrl_out": "10000"
+        },
+        {
+          "state_in": 2,
+          "ctrl_in": "x",
+          "state_out": 3,
+          "ctrl_out": "00100"
+        },
+        {
+          "state_in": 1,
+          "ctrl_in": "1",
+          "state_out": 3,
+          "ctrl_out": "00011"
+        },
+        {
+          "state_in": 1,
+          "ctrl_in": "0",
+          "state_out": 2,
+          "ctrl_out": "00011"
+        },
+        {
+          "state_in": 0,
+          "ctrl_in": "x",
+          "state_out": 1,
+          "ctrl_out": "01000"
+        }
+      ]
+    },
+    "dev5": {
+      "label": "$procmux$11_ANY",
+      "celltype": "$reduce_or",
+      "bits": 2
+    },
+    "dev6": {
+      "label": "$procmux$4",
+      "celltype": "$mux",
+      "bits": {
+        "in": 1,
+        "sel": 1
+      }
+    },
+    "dev7": {
+      "label": "$procmux$8",
+      "celltype": "$pmux",
+      "bits": {
+        "in": 1,
+        "sel": 3
+      }
+    },
+    "dev8": {
+      "celltype": "$busgroup",
+      "groups": [
+        1,
+        1,
+        1
+      ]
+    },
+    "dev9": {
+      "celltype": "$constant",
+      "constant": "0"
+    },
+    "dev10": {
+      "celltype": "$constant",
+      "constant": "1"
+    },
+    "dev11": {
+      "celltype": "$constant",
+      "constant": "x"
+    },
+    "dev12": {
+      "celltype": "$busslice",
+      "slice": {
+        "first": 3,
+        "count": 2,
+        "total": 5
+      }
+    },
+    "dev13": {
+      "celltype": "$busslice",
+      "slice": {
+        "first": 2,
+        "count": 1,
+        "total": 5
+      }
+    },
+    "dev14": {
+      "celltype": "$busslice",
+      "slice": {
+        "first": 1,
+        "count": 1,
+        "total": 5
+      }
+    }
+  },
+  "connectors": [
+    {
+      "to": {
+        "id": "dev4",
+        "port": "clk"
+      },
+      "from": {
+        "id": "dev0",
+        "port": "out"
+      },
+      "name": "clk"
+    },
+    {
+      "to": {
+        "id": "dev4",
+        "port": "arst"
+      },
+      "from": {
+        "id": "dev1",
+        "port": "out"
+      },
+      "name": "rst"
+    },
+    {
+      "to": {
+        "id": "dev4",
+        "port": "in"
+      },
+      "from": {
+        "id": "dev2",
+        "port": "out"
+      },
+      "name": "a"
+    },
+    {
+      "to": {
+        "id": "dev6",
+        "port": "sel"
+      },
+      "from": {
+        "id": "dev2",
+        "port": "out"
+      },
+      "name": "a"
+    },
+    {
+      "to": {
+        "id": "dev3",
+        "port": "in"
+      },
+      "from": {
+        "id": "dev7",
+        "port": "out"
+      },
+      "name": "b"
+    },
+    {
+      "to": {
+        "id": "dev12",
+        "port": "in"
+      },
+      "from": {
+        "id": "dev4",
+        "port": "out"
+      }
+    },
+    {
+      "to": {
+        "id": "dev13",
+        "port": "in"
+      },
+      "from": {
+        "id": "dev4",
+        "port": "out"
+      }
+    },
+    {
+      "to": {
+        "id": "dev14",
+        "port": "in"
+      },
+      "from": {
+        "id": "dev4",
+        "port": "out"
+      }
+    },
+    {
+      "to": {
+        "id": "dev5",
+        "port": "in"
+      },
+      "from": {
+        "id": "dev12",
+        "port": "out"
+      }
+    },
+    {
+      "to": {
+        "id": "dev8",
+        "port": "in0"
+      },
+      "from": {
+        "id": "dev5",
+        "port": "out"
+      }
+    },
+    {
+      "to": {
+        "id": "dev6",
+        "port": "in0"
+      },
+      "from": {
+        "id": "dev9",
+        "port": "out"
+      }
+    },
+    {
+      "to": {
+        "id": "dev7",
+        "port": "in1"
+      },
+      "from": {
+        "id": "dev9",
+        "port": "out"
+      }
+    },
+    {
+      "to": {
+        "id": "dev6",
+        "port": "in1"
+      },
+      "from": {
+        "id": "dev10",
+        "port": "out"
+      }
+    },
+    {
+      "to": {
+        "id": "dev7",
+        "port": "in2"
+      },
+      "from": {
+        "id": "dev10",
+        "port": "out"
+      }
+    },
+    {
+      "to": {
+        "id": "dev7",
+        "port": "in3"
+      },
+      "from": {
+        "id": "dev6",
+        "port": "out"
+      }
+    },
+    {
+      "to": {
+        "id": "dev7",
+        "port": "in0"
+      },
+      "from": {
+        "id": "dev11",
+        "port": "out"
+      }
+    },
+    {
+      "to": {
+        "id": "dev7",
+        "port": "sel"
+      },
+      "from": {
+        "id": "dev8",
+        "port": "out"
+      }
+    },
+    {
+      "to": {
+        "id": "dev8",
+        "port": "in1"
+      },
+      "from": {
+        "id": "dev13",
+        "port": "out"
+      }
+    },
+    {
+      "to": {
+        "id": "dev8",
+        "port": "in2"
+      },
+      "from": {
+        "id": "dev14",
+        "port": "out"
+      }
+    }
+  ],
+  "subcircuits": {}
+}

--- a/src/cells/fsm.js
+++ b/src/cells/fsm.js
@@ -122,7 +122,8 @@ export const FSM = Box.define('FSM', {
         this.set('next_trans', trans.id);
         if (!trans) return { out: Vector3vl.xes(bits.out) };
         else return { out: trans.get('ctrlOut') };
-    }
+    },
+    gateParams: Box.prototype.gateParams.concat(['bits', 'polarity', 'wirename', 'states', 'init_state', 'trans_table'])
 });
 
 export const FSMView = BoxView.extend({
@@ -157,15 +158,9 @@ export const FSMView = BoxView.extend({
             paper.fitToContent({ padding: 30, allowNewOrigin: 'any' });
         });
         paper.fitToContent({ padding: 30, allowNewOrigin: 'any' });
-        const maxWidth = $(window).width() * 0.9;
-        const maxHeight = $(window).height() * 0.9;
-        div.dialog({
-            width: Math.min(maxWidth, pdiv.outerWidth() + 60), 
-            height: Math.min(maxHeight, pdiv.outerHeight() + 60),
-            close: () => {
-                paper.remove();
-                div.remove();
-            }
+        this.paper.trigger('open:fsm', div, () => {
+            paper.remove();
+            div.remove();
         });
         return false;
     }

--- a/src/cells/memory.js
+++ b/src/cells/memory.js
@@ -290,13 +290,9 @@ export const MemoryView = BoxView.extend({
             setTimeout(() => { z.addClass('flash') }, 10);
         };
         this.model.on("memChange", changeCallback);
-        div.dialog({
-            width: 'auto',
-            resizable: false,
-            close: () => {
-                div.remove();
-                this.model.off("memChange", changeCallback);
-            }
+        this.paper.trigger('open:memorycontent', div, () => {
+            div.remove();
+            this.model.off("memChange", changeCallback);
         });
         return false;
     }

--- a/src/cells/subcircuit.js
+++ b/src/cells/subcircuit.js
@@ -84,8 +84,7 @@ export const SubcircuitView = BoxView.extend({
     },
     zoomInCircuit: function(evt) {
         evt.stopPropagation();
-        // TODO separate event type?
-        this.paper.trigger('cell:pointerdblclick', this, evt);
+        this.paper.trigger('open:subcircuit', this.model);
         return false;
     }
 });

--- a/src/index.js
+++ b/src/index.js
@@ -18,8 +18,9 @@ import './style.css';
 export { HeadlessCircuit, getCellType, MonitorView, Monitor };
 
 export class Circuit extends HeadlessCircuit {
-    constructor(data) {
+    constructor(data, windowCallback) {
         super(data);
+        this._windowCallback = windowCallback || this._defaultWindowCallback;
         this._interval_ms = 10;
         this._interval = null;
         this._idle = null;
@@ -67,6 +68,16 @@ export class Circuit extends HeadlessCircuit {
     shutdown() {
         super.shutdown();
         this.stop();
+    }
+    _defaultWindowCallback(type, div, closingCallback) {
+        div.dialog({
+            width: 'auto',
+            height: 'auto',
+            maxWidth: $(window).width() * 0.9,
+            maxHeight: $(window).height() * 0.9,
+            resizable: type === "Subcircuit",
+            close: closingCallback
+        });
     }
     displayOn(elem) {
         return this.makePaper(elem, this._graph);
@@ -119,37 +130,27 @@ export class Circuit extends HeadlessCircuit {
             });
             graph.set('laid_out', true);
         }
-        paper.unfreeze({
-            progress(done, processed, total) {
-                if (done) {
-                    paper.fitToContent({ padding: 30, allowNewOrigin: 'any' });
-                    if (opts.onDone) opts.onDone();
-                }
-            }
+        this.listenTo(paper, 'render:done', function() {
+            paper.fitToContent({ padding: 30, allowNewOrigin: 'any' });
         });
+        paper.unfreeze();
         // subcircuit display
-        this.listenTo(paper, 'cell:pointerdblclick', function(view, evt) {
-            if (!(view.model instanceof cells.Subcircuit)) return;
+        this.listenTo(paper, 'open:subcircuit', function(model) {
             const div = $('<div>', { 
-                title: view.model.get('celltype') + ' ' + view.model.get('label') 
+                title: model.get('celltype') + ' ' + model.get('label')
             }).appendTo('html > body');
             const pdiv = $('<div>').appendTo(div);
-            const graph = view.model.get('graph');
-            var didResize = false;
-            const paper = this.makePaper(pdiv, graph, {
-                onDone() {
-                    if (didResize) return;
-                    didResize = true;
-                    const maxWidth = $(window).width() * 0.9;
-                    const maxHeight = $(window).height() * 0.9;
-                    div.dialog({ width: Math.min(maxWidth, pdiv.outerWidth() + 60), height: Math.min(maxHeight, pdiv.outerHeight() + 60) });
-                    div.on('dialogclose', function(evt) {
-                        paper.remove();
-                        div.remove();
-                        circuit.trigger('remove:paper', paper);
-                    });
-                }
+            const graph = model.get('graph');
+            const paper = this.makePaper(pdiv, graph);
+            paper.once('render:done', function() {
+                circuit._windowCallback('Subcircuit', div, () => {
+                    paper.remove();
+                    div.remove();
+                });
             });
+        });
+        this.listenTo(paper, 'open:memorycontent', function(div, closeCallback) {
+            circuit._windowCallback('Memory', div, closeCallback);
         });
         paper.fixed = function(fixed) {
             this.setInteractivity(!fixed);

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ export class Circuit extends HeadlessCircuit {
             height: 'auto',
             maxWidth: $(window).width() * 0.9,
             maxHeight: $(window).height() * 0.9,
-            resizable: type === "Subcircuit",
+            resizable: type !== "Memory",
             close: closingCallback
         });
     }
@@ -151,6 +151,9 @@ export class Circuit extends HeadlessCircuit {
         });
         this.listenTo(paper, 'open:memorycontent', function(div, closeCallback) {
             circuit._windowCallback('Memory', div, closeCallback);
+        });
+        this.listenTo(paper, 'open:fsm', function(div, closeCallback) {
+            circuit._windowCallback('FSM', div, closeCallback);
         });
         paper.fixed = function(fixed) {
             this.setInteractivity(!fixed);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,8 @@ const tests = [
     {name: 'lfsr', title: 'Linear Feedback Shift Register'},
     {name: 'sextium', title: 'Sextium III Processor'},
     {name: 'rom', title: 'Async ROM'},
-    {name: 'ram', title: 'Simple RAM'}
+    {name: 'ram', title: 'Simple RAM'},
+    {name: 'fsm', title: 'Finite State Machine'}
 ];
 
 module.exports = {


### PR DESCRIPTION
This PR enables client-side webapps to handle subcircuits and memory content view freely by specifying a callback function at circuit initialization. If no callback is provided, the library defaults to the current behaviour (jQuery UI dialogs).

The containing div is automatically appended to `html > body` but can then be moved by webapps to different places to support e.g. tab view.

Fixes #6.