### PR TITLE
Allow ignoring layout information on serialization

### DIFF
--- a/examples/template.html
+++ b/examples/template.html
@@ -10,6 +10,7 @@
     <div>
         <input name="fixed" type="checkbox">Fixed Mode</input>
         <button name="json" type="button">Serialize and Reload</button>
+        <input name="layout" type="checkbox">Include layout information</button>
     </div>
     <div>
         <button name="ppt_up" type="button">+</button><button name="ppt_down">-</button><button name="left">&lt;</button><button name="right">&gt;</button><button name="live">live</button>
@@ -41,7 +42,7 @@
       $('button[name=json]').on('click', (e) => {
         monitorview.shutdown();
         circuit.stop();
-        const json = circuit.toJSON();
+        const json = circuit.toJSON($('input[name=layout]').prop('checked'));
         console.log(json);
         loadCircuit(json);
       });

--- a/src/cells/base.js
+++ b/src/cells/base.js
@@ -85,10 +85,11 @@ export const Gate = joint.shapes.basic.Generic.define('Gate', {
         }
         return '<g>' + markup + '</g>';
     },
-    getGateParams: function() {
-        return _.cloneDeep(_.pick(this.attributes, this.gateParams))
+    getGateParams: function(layout) {
+        return _.cloneDeep(_.pick(this.attributes, this.gateParams.concat(layout ? this.gateLayoutParams : [])));
     },
-    gateParams: ['label', 'position', 'type', 'propagation']
+    gateParams: ['label', 'type', 'propagation'],
+    gateLayoutParams: ['position']
 });
 
 export const GateView = joint.dia.ElementView.extend({
@@ -208,7 +209,7 @@ export const Wire = joint.dia.Link.define('Wire', {
             });
         }
     },
-    getWireParams: function() {
+    getWireParams: function(layout) {
         const connector = {
             from: {
                 id: this.get('source').id,
@@ -221,7 +222,7 @@ export const Wire = joint.dia.Link.define('Wire', {
         };
         if (this.has('netname'))
             connector.name = this.get('netname');
-        if (this.has('vertices'))
+        if (layout && this.has('vertices') && this.get('vertices').length > 0)
             connector.vertices = _.cloneDeep(this.get('vertices'));
         return connector;
     }

--- a/src/circuit.js
+++ b/src/circuit.js
@@ -260,7 +260,7 @@ export class HeadlessCircuit {
         }
         return fromGraph(this._graph);
     }
-    toJSON() {
+    toJSON(layout = true) {
         const subcircuits = {};
         const circuit = this;
         function fromGraph(graph) {
@@ -270,14 +270,14 @@ export class HeadlessCircuit {
             };
             const laid_out = graph.get('laid_out');
             for (const elem of graph.getElements()) {
-                const args = ret.devices[elem.get('id')] = elem.getGateParams();
+                const args = ret.devices[elem.get('id')] = elem.getGateParams(layout);
                 if (!laid_out) delete args.position;
                 if (elem instanceof circuit._cells.Subcircuit && !subcircuits[elem.get('celltype')]) {
                     subcircuits[elem.get('celltype')] = fromGraph(elem.get('graph'));
                 }
             }
             for (const elem of graph.getLinks()) {
-                ret.connectors.push(elem.getWireParams());
+                ret.connectors.push(elem.getWireParams(layout));
             }
             return ret;
         }


### PR DESCRIPTION
This PR adds a new optional argument to `toJSON()` to allow ignoring layout information while saving a circuit to json. Also adapts slightly the examples template to see the new behavior. For backward compatibility, it defaults to saving the layout information.