### PR TITLE
Refactor class hierarchy, markup and ports

### DIFF
--- a/examples/gates.json
+++ b/examples/gates.json
@@ -1,0 +1,687 @@
+{
+  "devices": {
+    "54c9125d-c454-4f3f-9566-58687b2b23a9": {
+      "label": "Not",
+      "type": "Not",
+      "propagation": 1,
+      "bits": 1,
+      "position": {
+        "x": 0,
+        "y": 0
+      }
+    },
+    "a0cbdc4d-ff94-45ba-ad3f-7e43f676be85": {
+      "label": "And",
+      "type": "And",
+      "propagation": 1,
+      "bits": 1,
+      "position": {
+        "x": 0,
+        "y": 100
+      }
+    },
+    "f065d6ab-d1a0-48be-bb3f-7d6586f7371f": {
+      "label": "Nand",
+      "type": "Nand",
+      "propagation": 1,
+      "bits": 1,
+      "position": {
+        "x": 0,
+        "y": 200
+      }
+    },
+    "61535731-f2a0-402f-8a69-ecad4cb64d72": {
+      "label": "Or",
+      "type": "Or",
+      "propagation": 1,
+      "bits": 1,
+      "position": {
+        "x": 0,
+        "y": 300
+      }
+    },
+    "a51ea406-646a-44e1-ad5e-7089d96fcd3b": {
+      "label": "Nor",
+      "type": "Nor",
+      "propagation": 1,
+      "bits": 1,
+      "position": {
+        "x": 0,
+        "y": 400
+      }
+    },
+    "4695ee1e-866a-45ef-b239-c75804b73340": {
+      "label": "Xor",
+      "type": "Xor",
+      "propagation": 1,
+      "bits": 1,
+      "position": {
+        "x": 0,
+        "y": 500
+      }
+    },
+    "fccbd528-38e3-496c-b549-f954158ff5cf": {
+      "label": "Xnor",
+      "type": "Xnor",
+      "propagation": 1,
+      "bits": 1,
+      "position": {
+        "x": 0,
+        "y": 600
+      }
+    },
+    "687b7df3-2309-4bcb-9c6a-7d1d5355ff83": {
+      "label": "ShiftLeft",
+      "type": "ShiftLeft",
+      "propagation": 1,
+      "bits": {
+        "in1": 1,
+        "in2": 1,
+        "out": 1
+      },
+      "signed": {
+        "in1": false,
+        "in2": false,
+        "out": false
+      },
+      "fillx": false,
+      "position": {
+        "x": 0,
+        "y": 700
+      }
+    },
+    "68fcf7ae-5e31-4971-a7e2-273bf7a7e9d5": {
+      "label": "ShiftRight",
+      "type": "ShiftRight",
+      "propagation": 1,
+      "bits": {
+        "in1": 1,
+        "in2": 1,
+        "out": 1
+      },
+      "signed": {
+        "in1": false,
+        "in2": false,
+        "out": false
+      },
+      "fillx": false,
+      "position": {
+        "x": 0,
+        "y": 800
+      }
+    },
+    "9d48f119-ef4d-4f9c-a21d-677fcb8f4789": {
+      "label": "AndReduce",
+      "type": "AndReduce",
+      "propagation": 1,
+      "bits": 1,
+      "position": {
+        "x": 200,
+        "y": 0
+      }
+    },
+    "7e4da2be-dd9a-41ba-936a-313902652586": {
+      "label": "NandReduce",
+      "type": "NandReduce",
+      "propagation": 1,
+      "bits": 1,
+      "position": {
+        "x": 200,
+        "y": 100
+      }
+    },
+    "4b442584-606c-477b-8801-10dd9fc7d7f6": {
+      "label": "OrReduce",
+      "type": "OrReduce",
+      "propagation": 1,
+      "bits": 1,
+      "position": {
+        "x": 200,
+        "y": 200
+      }
+    },
+    "40ea5c1e-6e9d-41c7-89bf-98ece03152ca": {
+      "label": "NorReduce",
+      "type": "NorReduce",
+      "propagation": 1,
+      "bits": 1,
+      "position": {
+        "x": 200,
+        "y": 300
+      }
+    },
+    "990efdb0-e01d-48d5-bb2e-5232f67a9e97": {
+      "label": "XorReduce",
+      "type": "XorReduce",
+      "propagation": 1,
+      "bits": 1,
+      "position": {
+        "x": 200,
+        "y": 400
+      }
+    },
+    "9bdd77b2-6900-4d72-9c4d-ee5361826086": {
+      "label": "Eq",
+      "type": "Eq",
+      "propagation": 1,
+      "bits": {
+        "in1": 1,
+        "in2": 1
+      },
+      "signed": {
+        "in1": false,
+        "in2": false
+      },
+      "position": {
+        "x": 400,
+        "y": 0
+      }
+    },
+    "50a71b3d-7710-4825-8e7b-4c65b9ee3b6a": {
+      "label": "Ne",
+      "type": "Ne",
+      "propagation": 1,
+      "bits": {
+        "in1": 1,
+        "in2": 1
+      },
+      "signed": {
+        "in1": false,
+        "in2": false
+      },
+      "position": {
+        "x": 400,
+        "y": 100
+      }
+    },
+    "6d74067c-1145-4ef2-bfdb-e29212bf084c": {
+      "label": "Lt",
+      "type": "Lt",
+      "propagation": 1,
+      "bits": {
+        "in1": 1,
+        "in2": 1
+      },
+      "signed": {
+        "in1": false,
+        "in2": false
+      },
+      "position": {
+        "x": 400,
+        "y": 200
+      }
+    },
+    "89d471b0-8642-4496-b5f0-392edc190d3d": {
+      "label": "Le",
+      "type": "Le",
+      "propagation": 1,
+      "bits": {
+        "in1": 1,
+        "in2": 1
+      },
+      "signed": {
+        "in1": false,
+        "in2": false
+      },
+      "position": {
+        "x": 400,
+        "y": 300
+      }
+    },
+    "47490c62-6d66-48d8-ae22-a485de0569cc": {
+      "label": "Gt",
+      "type": "Gt",
+      "propagation": 1,
+      "bits": {
+        "in1": 1,
+        "in2": 1
+      },
+      "signed": {
+        "in1": false,
+        "in2": false
+      },
+      "position": {
+        "x": 400,
+        "y": 400
+      }
+    },
+    "e5b28efa-1b17-4b63-821b-39eac780d72a": {
+      "label": "Ge",
+      "type": "Ge",
+      "propagation": 1,
+      "bits": {
+        "in1": 1,
+        "in2": 1
+      },
+      "signed": {
+        "in1": false,
+        "in2": false
+      },
+      "position": {
+        "x": 400,
+        "y": 500
+      }
+    },
+    "36aba417-2dec-4264-b5db-5a1bade48911": {
+      "label": "Negation",
+      "type": "Negation",
+      "propagation": 1,
+      "bits": {
+        "in": 1,
+        "out": 1
+      },
+      "signed": false,
+      "position": {
+        "x": 600,
+        "y": 0
+      }
+    },
+    "f8a99ab4-567c-474d-b9bf-efc084adf59c": {
+      "label": "UnaryPlus",
+      "type": "UnaryPlus",
+      "propagation": 1,
+      "bits": {
+        "in": 1,
+        "out": 1
+      },
+      "signed": false,
+      "position": {
+        "x": 600,
+        "y": 100
+      }
+    },
+    "7b484788-c8b4-4f6a-9bd7-ffc52bf20410": {
+      "label": "Addition",
+      "type": "Addition",
+      "propagation": 1,
+      "bits": {
+        "in1": 1,
+        "in2": 1,
+        "out": 1
+      },
+      "signed": {
+        "in1": false,
+        "in2": false
+      },
+      "position": {
+        "x": 600,
+        "y": 200
+      }
+    },
+    "7c04f2e1-e71c-4b7e-bd8f-8ec4a92d7346": {
+      "label": "Subtraction",
+      "type": "Subtraction",
+      "propagation": 1,
+      "bits": {
+        "in1": 1,
+        "in2": 1,
+        "out": 1
+      },
+      "signed": {
+        "in1": false,
+        "in2": false
+      },
+      "position": {
+        "x": 600,
+        "y": 300
+      }
+    },
+    "a3b1073a-580e-41cf-aff3-91fc7583272b": {
+      "label": "Multiplication",
+      "type": "Multiplication",
+      "propagation": 1,
+      "bits": {
+        "in1": 1,
+        "in2": 1,
+        "out": 1
+      },
+      "signed": {
+        "in1": false,
+        "in2": false
+      },
+      "position": {
+        "x": 600,
+        "y": 400
+      }
+    },
+    "261d9bb1-3207-4135-96db-3d24487754fd": {
+      "label": "Division",
+      "type": "Division",
+      "propagation": 1,
+      "bits": {
+        "in1": 1,
+        "in2": 1,
+        "out": 1
+      },
+      "signed": {
+        "in1": false,
+        "in2": false
+      },
+      "position": {
+        "x": 600,
+        "y": 500
+      }
+    },
+    "ef4b605c-743f-4533-8d71-1236bdc3f1f3": {
+      "label": "Modulo",
+      "type": "Modulo",
+      "propagation": 1,
+      "bits": {
+        "in1": 1,
+        "in2": 1,
+        "out": 1
+      },
+      "signed": {
+        "in1": false,
+        "in2": false
+      },
+      "position": {
+        "x": 600,
+        "y": 600
+      }
+    },
+    "5d39da66-996c-4624-8c2b-88978e4e1395": {
+      "label": "Power",
+      "type": "Power",
+      "propagation": 1,
+      "bits": {
+        "in1": 1,
+        "in2": 1,
+        "out": 1
+      },
+      "signed": {
+        "in1": false,
+        "in2": false
+      },
+      "position": {
+        "x": 600,
+        "y": 700
+      }
+    },
+    "bcda2ceb-83c8-4ebc-aefe-57e2e98201aa": {
+      "label": "Constant",
+      "type": "Constant",
+      "propagation": 0,
+      "numbase": "hex",
+      "constant": 0,
+      "position": {
+        "x": 800,
+        "y": 0
+      }
+    },
+    "4d02d820-9a6a-4ba0-9e76-212be041414c": {
+      "label": "Clock",
+      "type": "Clock",
+      "propagation": 100,
+      "position": {
+        "x": 800,
+        "y": 100
+      }
+    },
+    "044f875f-1926-4911-8336-5d91ad3edf67": {
+      "label": "Button",
+      "type": "Button",
+      "propagation": 0,
+      "position": {
+        "x": 800,
+        "y": 200
+      }
+    },
+    "5cb2f869-4852-4447-b4cd-fdcd01442c93": {
+      "label": "Lamp",
+      "type": "Lamp",
+      "propagation": 1,
+      "position": {
+        "x": 800,
+        "y": 300
+      }
+    },
+    "d81f4f5f-16dd-4fae-954d-db6666e070ac": {
+      "label": "NumEntry",
+      "type": "NumEntry",
+      "propagation": 0,
+      "numbase": "hex",
+      "bits": 1,
+      "position": {
+        "x": 800,
+        "y": 400
+      }
+    },
+    "383468e5-fb2f-47a1-8beb-87df81cf9916": {
+      "label": "NumDisplay",
+      "type": "NumDisplay",
+      "propagation": 0,
+      "numbase": "hex",
+      "bits": 1,
+      "position": {
+        "x": 800,
+        "y": 500
+      }
+    },
+    "30bc9df9-69e9-41e3-b230-3d999dc48330": {
+      "label": "Input",
+      "type": "Input",
+      "propagation": 0,
+      "bits": 1,
+      "net": "in",
+      "position": {
+        "x": 800,
+        "y": 600
+      }
+    },
+    "469d38ad-9177-433c-ab62-9d82f914fc1a": {
+      "label": "Output",
+      "type": "Output",
+      "propagation": 0,
+      "bits": 1,
+      "net": "out",
+      "position": {
+        "x": 800,
+        "y": 700
+      }
+    },
+    "635e6db5-8e90-4f37-864a-23ebbd21e398": {
+      "label": "Repeater",
+      "type": "Repeater",
+      "propagation": 1,
+      "bits": 1,
+      "position": {
+        "x": 1000,
+        "y": 0
+      }
+    },
+    "434adf98-f7ea-4355-82da-60dd1d1555ec": {
+      "label": "BusGroup",
+      "type": "BusGroup",
+      "propagation": 0,
+      "groups": [
+        1,
+        1
+      ],
+      "position": {
+        "x": 1000,
+        "y": 100
+      }
+    },
+    "10ddb9f6-850b-48e8-84f4-48c941cf1bb3": {
+      "label": "BusUngroup",
+      "type": "BusUngroup",
+      "propagation": 0,
+      "groups": [
+        1,
+        1
+      ],
+      "position": {
+        "x": 1000,
+        "y": 200
+      }
+    },
+    "161945c4-37aa-4f94-872a-97508a6771f9": {
+      "label": "BusSlice",
+      "type": "BusSlice",
+      "propagation": 0,
+      "slice": {
+        "first": 0,
+        "count": 1,
+        "total": 2
+      },
+      "position": {
+        "x": 1000,
+        "y": 300
+      }
+    },
+    "6228c4f1-3503-42cc-a015-4ca1257b7e20": {
+      "label": "ZeroExtend",
+      "type": "ZeroExtend",
+      "propagation": 0,
+      "extend": {
+        "input": 1,
+        "output": 1
+      },
+      "position": {
+        "x": 1000,
+        "y": 400
+      }
+    },
+    "5742dc12-84d9-4f0f-b0df-1491cab43ae0": {
+      "label": "SignExtend",
+      "type": "SignExtend",
+      "propagation": 0,
+      "extend": {
+        "input": 1,
+        "output": 1
+      },
+      "position": {
+        "x": 1000,
+        "y": 500
+      }
+    },
+    "63b6c98a-49c8-4f80-ab0b-008aa313f5e4": {
+      "label": "Mux",
+      "type": "Mux",
+      "propagation": 1,
+      "bits": {
+        "in": 1,
+        "sel": 1
+      },
+      "position": {
+        "x": 1200,
+        "y": 0
+      }
+    },
+    "34a53445-af90-411c-9179-01845e3b1d95": {
+      "label": "Mux1Hot",
+      "type": "Mux1Hot",
+      "propagation": 1,
+      "bits": {
+        "in": 1,
+        "sel": 1
+      },
+      "position": {
+        "x": 1200,
+        "y": 100
+      }
+    },
+    "f6f4a995-d6bb-4ef8-bc34-a568e193a8dc": {
+      "label": "Dff",
+      "type": "Dff",
+      "propagation": 1,
+      "polarity": {
+        "clock": true
+      },
+      "bits": 1,
+      "initial": "x",
+      "position": {
+        "x": 1200,
+        "y": 200
+      }
+    },
+    "ba9dbbd7-8dd1-43ad-bd60-9f1a63656d84": {
+      "label": "Subcircuit",
+      "type": "Subcircuit",
+      "propagation": 0,
+      "celltype": "pipe",
+      "position": {
+        "x": 1200,
+        "y": 300
+      }
+    },
+    "0662e43f-477e-4140-a79b-6c3e38f173c9": {
+      "label": "FSM",
+      "type": "FSM",
+      "propagation": 1,
+      "bits": {
+        "in": 1,
+        "out": 1
+      },
+      "polarity": {
+        "clock": true
+      },
+      "states": 1,
+      "init_state": 0,
+      "trans_table": [],
+      "position": {
+        "x": 1200,
+        "y": 400
+      }
+    },
+    "ecac6e41-deb2-4e34-94af-7e74f8b5047c": {
+      "label": "Memory",
+      "type": "Memory",
+      "propagation": 1,
+      "bits": 1,
+      "abits": 1,
+      "rdports": [
+        {
+          "clock_polarity": true
+        }
+      ],
+      "wrports": [
+        {}
+      ],
+      "words": 2,
+      "offset": 0,
+      "position": {
+        "x": 1200,
+        "y": 500
+      },
+      "memdata": [
+        2,
+        "x"
+      ]
+    }
+  },
+  "connectors": [],
+  "subcircuits": {
+    "pipe": {
+      "devices": {
+        "in": {
+          "label": "",
+          "type": "Input",
+          "propagation": 0,
+          "bits": 1,
+          "net": "i"
+        },
+        "out": {
+          "label": "",
+          "type": "Output",
+          "propagation": 0,
+          "bits": 1,
+          "net": "o"
+        }
+      },
+      "connectors": [
+        {
+          "from": {
+            "id": "in",
+            "port": "out"
+          },
+          "to": {
+            "id": "out",
+            "port": "in"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/examples/gates.json
+++ b/examples/gates.json
@@ -2,653 +2,388 @@
   "devices": {
     "54c9125d-c454-4f3f-9566-58687b2b23a9": {
       "label": "Not",
-      "type": "Not",
-      "propagation": 1,
-      "bits": 1,
       "position": {
         "x": 0,
         "y": 0
-      }
+      },
+      "type": "Not"
     },
     "a0cbdc4d-ff94-45ba-ad3f-7e43f676be85": {
       "label": "And",
-      "type": "And",
-      "propagation": 1,
-      "bits": 1,
       "position": {
         "x": 0,
         "y": 100
-      }
+      },
+      "type": "And"
     },
     "f065d6ab-d1a0-48be-bb3f-7d6586f7371f": {
       "label": "Nand",
-      "type": "Nand",
-      "propagation": 1,
-      "bits": 1,
       "position": {
         "x": 0,
         "y": 200
-      }
+      },
+      "type": "Nand"
     },
     "61535731-f2a0-402f-8a69-ecad4cb64d72": {
       "label": "Or",
-      "type": "Or",
-      "propagation": 1,
-      "bits": 1,
       "position": {
         "x": 0,
         "y": 300
-      }
+      },
+      "type": "Or"
     },
     "a51ea406-646a-44e1-ad5e-7089d96fcd3b": {
       "label": "Nor",
-      "type": "Nor",
-      "propagation": 1,
-      "bits": 1,
       "position": {
         "x": 0,
         "y": 400
-      }
+      },
+      "type": "Nor"
     },
     "4695ee1e-866a-45ef-b239-c75804b73340": {
       "label": "Xor",
-      "type": "Xor",
-      "propagation": 1,
-      "bits": 1,
       "position": {
         "x": 0,
         "y": 500
-      }
+      },
+      "type": "Xor"
     },
     "fccbd528-38e3-496c-b549-f954158ff5cf": {
       "label": "Xnor",
-      "type": "Xnor",
-      "propagation": 1,
-      "bits": 1,
       "position": {
         "x": 0,
         "y": 600
-      }
+      },
+      "type": "Xnor"
     },
     "687b7df3-2309-4bcb-9c6a-7d1d5355ff83": {
       "label": "ShiftLeft",
-      "type": "ShiftLeft",
-      "propagation": 1,
-      "bits": {
-        "in1": 1,
-        "in2": 1,
-        "out": 1
-      },
-      "signed": {
-        "in1": false,
-        "in2": false,
-        "out": false
-      },
-      "fillx": false,
       "position": {
         "x": 0,
         "y": 700
-      }
+      },
+      "type": "ShiftLeft"
     },
     "68fcf7ae-5e31-4971-a7e2-273bf7a7e9d5": {
       "label": "ShiftRight",
-      "type": "ShiftRight",
-      "propagation": 1,
-      "bits": {
-        "in1": 1,
-        "in2": 1,
-        "out": 1
-      },
-      "signed": {
-        "in1": false,
-        "in2": false,
-        "out": false
-      },
-      "fillx": false,
       "position": {
         "x": 0,
         "y": 800
-      }
+      },
+      "type": "ShiftRight"
     },
     "9d48f119-ef4d-4f9c-a21d-677fcb8f4789": {
       "label": "AndReduce",
-      "type": "AndReduce",
-      "propagation": 1,
-      "bits": 1,
       "position": {
         "x": 200,
         "y": 0
-      }
+      },
+      "type": "AndReduce"
     },
     "7e4da2be-dd9a-41ba-936a-313902652586": {
       "label": "NandReduce",
-      "type": "NandReduce",
-      "propagation": 1,
-      "bits": 1,
       "position": {
         "x": 200,
         "y": 100
-      }
+      },
+      "type": "NandReduce"
     },
     "4b442584-606c-477b-8801-10dd9fc7d7f6": {
       "label": "OrReduce",
-      "type": "OrReduce",
-      "propagation": 1,
-      "bits": 1,
       "position": {
         "x": 200,
         "y": 200
-      }
+      },
+      "type": "OrReduce"
     },
     "40ea5c1e-6e9d-41c7-89bf-98ece03152ca": {
       "label": "NorReduce",
-      "type": "NorReduce",
-      "propagation": 1,
-      "bits": 1,
       "position": {
         "x": 200,
         "y": 300
-      }
+      },
+      "type": "NorReduce"
     },
     "990efdb0-e01d-48d5-bb2e-5232f67a9e97": {
       "label": "XorReduce",
-      "type": "XorReduce",
-      "propagation": 1,
-      "bits": 1,
       "position": {
         "x": 200,
         "y": 400
-      }
+      },
+      "type": "XorReduce"
     },
     "9bdd77b2-6900-4d72-9c4d-ee5361826086": {
       "label": "Eq",
-      "type": "Eq",
-      "propagation": 1,
-      "bits": {
-        "in1": 1,
-        "in2": 1
-      },
-      "signed": {
-        "in1": false,
-        "in2": false
-      },
       "position": {
         "x": 400,
         "y": 0
-      }
+      },
+      "type": "Eq"
     },
     "50a71b3d-7710-4825-8e7b-4c65b9ee3b6a": {
       "label": "Ne",
-      "type": "Ne",
-      "propagation": 1,
-      "bits": {
-        "in1": 1,
-        "in2": 1
-      },
-      "signed": {
-        "in1": false,
-        "in2": false
-      },
       "position": {
         "x": 400,
         "y": 100
-      }
+      },
+      "type": "Ne"
     },
     "6d74067c-1145-4ef2-bfdb-e29212bf084c": {
       "label": "Lt",
-      "type": "Lt",
-      "propagation": 1,
-      "bits": {
-        "in1": 1,
-        "in2": 1
-      },
-      "signed": {
-        "in1": false,
-        "in2": false
-      },
       "position": {
         "x": 400,
         "y": 200
-      }
+      },
+      "type": "Lt"
     },
     "89d471b0-8642-4496-b5f0-392edc190d3d": {
       "label": "Le",
-      "type": "Le",
-      "propagation": 1,
-      "bits": {
-        "in1": 1,
-        "in2": 1
-      },
-      "signed": {
-        "in1": false,
-        "in2": false
-      },
       "position": {
         "x": 400,
         "y": 300
-      }
+      },
+      "type": "Le"
     },
     "47490c62-6d66-48d8-ae22-a485de0569cc": {
       "label": "Gt",
-      "type": "Gt",
-      "propagation": 1,
-      "bits": {
-        "in1": 1,
-        "in2": 1
-      },
-      "signed": {
-        "in1": false,
-        "in2": false
-      },
       "position": {
         "x": 400,
         "y": 400
-      }
+      },
+      "type": "Gt"
     },
     "e5b28efa-1b17-4b63-821b-39eac780d72a": {
       "label": "Ge",
-      "type": "Ge",
-      "propagation": 1,
-      "bits": {
-        "in1": 1,
-        "in2": 1
-      },
-      "signed": {
-        "in1": false,
-        "in2": false
-      },
       "position": {
         "x": 400,
         "y": 500
-      }
+      },
+      "type": "Ge"
     },
     "36aba417-2dec-4264-b5db-5a1bade48911": {
       "label": "Negation",
-      "type": "Negation",
-      "propagation": 1,
-      "bits": {
-        "in": 1,
-        "out": 1
-      },
-      "signed": false,
       "position": {
         "x": 600,
         "y": 0
-      }
+      },
+      "type": "Negation"
     },
     "f8a99ab4-567c-474d-b9bf-efc084adf59c": {
       "label": "UnaryPlus",
-      "type": "UnaryPlus",
-      "propagation": 1,
-      "bits": {
-        "in": 1,
-        "out": 1
-      },
-      "signed": false,
       "position": {
         "x": 600,
         "y": 100
-      }
+      },
+      "type": "UnaryPlus"
     },
     "7b484788-c8b4-4f6a-9bd7-ffc52bf20410": {
       "label": "Addition",
-      "type": "Addition",
-      "propagation": 1,
-      "bits": {
-        "in1": 1,
-        "in2": 1,
-        "out": 1
-      },
-      "signed": {
-        "in1": false,
-        "in2": false
-      },
       "position": {
         "x": 600,
         "y": 200
-      }
+      },
+      "type": "Addition"
     },
     "7c04f2e1-e71c-4b7e-bd8f-8ec4a92d7346": {
       "label": "Subtraction",
-      "type": "Subtraction",
-      "propagation": 1,
-      "bits": {
-        "in1": 1,
-        "in2": 1,
-        "out": 1
-      },
-      "signed": {
-        "in1": false,
-        "in2": false
-      },
       "position": {
         "x": 600,
         "y": 300
-      }
+      },
+      "type": "Subtraction"
     },
     "a3b1073a-580e-41cf-aff3-91fc7583272b": {
       "label": "Multiplication",
-      "type": "Multiplication",
-      "propagation": 1,
-      "bits": {
-        "in1": 1,
-        "in2": 1,
-        "out": 1
-      },
-      "signed": {
-        "in1": false,
-        "in2": false
-      },
       "position": {
         "x": 600,
         "y": 400
-      }
+      },
+      "type": "Multiplication"
     },
     "261d9bb1-3207-4135-96db-3d24487754fd": {
       "label": "Division",
-      "type": "Division",
-      "propagation": 1,
-      "bits": {
-        "in1": 1,
-        "in2": 1,
-        "out": 1
-      },
-      "signed": {
-        "in1": false,
-        "in2": false
-      },
       "position": {
         "x": 600,
         "y": 500
-      }
+      },
+      "type": "Division"
     },
     "ef4b605c-743f-4533-8d71-1236bdc3f1f3": {
       "label": "Modulo",
-      "type": "Modulo",
-      "propagation": 1,
-      "bits": {
-        "in1": 1,
-        "in2": 1,
-        "out": 1
-      },
-      "signed": {
-        "in1": false,
-        "in2": false
-      },
       "position": {
         "x": 600,
         "y": 600
-      }
+      },
+      "type": "Modulo"
     },
     "5d39da66-996c-4624-8c2b-88978e4e1395": {
       "label": "Power",
-      "type": "Power",
-      "propagation": 1,
-      "bits": {
-        "in1": 1,
-        "in2": 1,
-        "out": 1
-      },
-      "signed": {
-        "in1": false,
-        "in2": false
-      },
       "position": {
         "x": 600,
         "y": 700
-      }
+      },
+      "type": "Power"
     },
     "bcda2ceb-83c8-4ebc-aefe-57e2e98201aa": {
       "label": "Constant",
-      "type": "Constant",
-      "propagation": 0,
-      "numbase": "hex",
-      "constant": 0,
       "position": {
         "x": 800,
         "y": 0
-      }
+      },
+      "type": "Constant"
     },
     "4d02d820-9a6a-4ba0-9e76-212be041414c": {
       "label": "Clock",
-      "type": "Clock",
-      "propagation": 100,
       "position": {
         "x": 800,
         "y": 100
-      }
+      },
+      "type": "Clock"
     },
     "044f875f-1926-4911-8336-5d91ad3edf67": {
       "label": "Button",
-      "type": "Button",
-      "propagation": 0,
       "position": {
         "x": 800,
         "y": 200
-      }
+      },
+      "type": "Button"
     },
     "5cb2f869-4852-4447-b4cd-fdcd01442c93": {
       "label": "Lamp",
-      "type": "Lamp",
-      "propagation": 1,
       "position": {
         "x": 800,
         "y": 300
-      }
+      },
+      "type": "Lamp"
     },
     "d81f4f5f-16dd-4fae-954d-db6666e070ac": {
       "label": "NumEntry",
-      "type": "NumEntry",
-      "propagation": 0,
-      "numbase": "hex",
-      "bits": 1,
       "position": {
         "x": 800,
         "y": 400
-      }
+      },
+      "type": "NumEntry"
     },
     "383468e5-fb2f-47a1-8beb-87df81cf9916": {
       "label": "NumDisplay",
-      "type": "NumDisplay",
-      "propagation": 0,
-      "numbase": "hex",
-      "bits": 1,
       "position": {
         "x": 800,
         "y": 500
-      }
+      },
+      "type": "NumDisplay"
     },
     "30bc9df9-69e9-41e3-b230-3d999dc48330": {
       "label": "Input",
-      "type": "Input",
-      "propagation": 0,
-      "bits": 1,
-      "net": "in",
       "position": {
         "x": 800,
         "y": 600
-      }
+      },
+      "type": "Input"
     },
     "469d38ad-9177-433c-ab62-9d82f914fc1a": {
       "label": "Output",
-      "type": "Output",
-      "propagation": 0,
-      "bits": 1,
-      "net": "out",
       "position": {
         "x": 800,
         "y": 700
-      }
+      },
+      "type": "Output"
     },
     "635e6db5-8e90-4f37-864a-23ebbd21e398": {
       "label": "Repeater",
-      "type": "Repeater",
-      "propagation": 1,
-      "bits": 1,
       "position": {
         "x": 1000,
         "y": 0
-      }
+      },
+      "type": "Repeater"
     },
     "434adf98-f7ea-4355-82da-60dd1d1555ec": {
       "label": "BusGroup",
-      "type": "BusGroup",
-      "propagation": 0,
-      "groups": [
-        1,
-        1
-      ],
       "position": {
         "x": 1000,
         "y": 100
-      }
+      },
+      "type": "BusGroup"
     },
     "10ddb9f6-850b-48e8-84f4-48c941cf1bb3": {
       "label": "BusUngroup",
-      "type": "BusUngroup",
-      "propagation": 0,
-      "groups": [
-        1,
-        1
-      ],
       "position": {
         "x": 1000,
         "y": 200
-      }
+      },
+      "type": "BusUngroup"
     },
     "161945c4-37aa-4f94-872a-97508a6771f9": {
       "label": "BusSlice",
-      "type": "BusSlice",
-      "propagation": 0,
-      "slice": {
-        "first": 0,
-        "count": 1,
-        "total": 2
-      },
       "position": {
         "x": 1000,
         "y": 300
-      }
+      },
+      "type": "BusSlice"
     },
     "6228c4f1-3503-42cc-a015-4ca1257b7e20": {
       "label": "ZeroExtend",
-      "type": "ZeroExtend",
-      "propagation": 0,
-      "extend": {
-        "input": 1,
-        "output": 1
-      },
       "position": {
         "x": 1000,
         "y": 400
-      }
+      },
+      "type": "ZeroExtend"
     },
     "5742dc12-84d9-4f0f-b0df-1491cab43ae0": {
       "label": "SignExtend",
-      "type": "SignExtend",
-      "propagation": 0,
-      "extend": {
-        "input": 1,
-        "output": 1
-      },
       "position": {
         "x": 1000,
         "y": 500
-      }
+      },
+      "type": "SignExtend"
     },
     "63b6c98a-49c8-4f80-ab0b-008aa313f5e4": {
       "label": "Mux",
-      "type": "Mux",
-      "propagation": 1,
-      "bits": {
-        "in": 1,
-        "sel": 1
-      },
       "position": {
         "x": 1200,
         "y": 0
-      }
+      },
+      "type": "Mux"
     },
     "34a53445-af90-411c-9179-01845e3b1d95": {
       "label": "Mux1Hot",
-      "type": "Mux1Hot",
-      "propagation": 1,
-      "bits": {
-        "in": 1,
-        "sel": 1
-      },
       "position": {
         "x": 1200,
         "y": 100
-      }
+      },
+      "type": "Mux1Hot"
     },
     "f6f4a995-d6bb-4ef8-bc34-a568e193a8dc": {
       "label": "Dff",
-      "type": "Dff",
-      "propagation": 1,
-      "polarity": {
-        "clock": true
-      },
-      "bits": 1,
-      "initial": "x",
       "position": {
         "x": 1200,
         "y": 200
-      }
+      },
+      "type": "Dff"
     },
     "ba9dbbd7-8dd1-43ad-bd60-9f1a63656d84": {
       "label": "Subcircuit",
-      "type": "Subcircuit",
-      "propagation": 0,
-      "celltype": "pipe",
       "position": {
         "x": 1200,
         "y": 300
-      }
+      },
+      "type": "Subcircuit",
+      "celltype": "pipe"
     },
     "0662e43f-477e-4140-a79b-6c3e38f173c9": {
       "label": "FSM",
-      "type": "FSM",
-      "propagation": 1,
-      "bits": {
-        "in": 1,
-        "out": 1
-      },
-      "polarity": {
-        "clock": true
-      },
-      "states": 1,
-      "init_state": 0,
-      "trans_table": [],
       "position": {
         "x": 1200,
         "y": 400
-      }
+      },
+      "type": "FSM"
     },
     "ecac6e41-deb2-4e34-94af-7e74f8b5047c": {
       "label": "Memory",
-      "type": "Memory",
-      "propagation": 1,
-      "bits": 1,
-      "abits": 1,
-      "rdports": [
-        {
-          "clock_polarity": true
-        }
-      ],
-      "wrports": [
-        {}
-      ],
-      "words": 2,
-      "offset": 0,
       "position": {
         "x": 1200,
         "y": 500
       },
-      "memdata": [
-        2,
-        "x"
-      ]
+      "type": "Memory"
     }
   },
   "connectors": [],
@@ -656,14 +391,12 @@
     "pipe": {
       "devices": {
         "in": {
-          "label": "",
           "type": "Input",
           "propagation": 0,
           "bits": 1,
           "net": "i"
         },
         "out": {
-          "label": "",
           "type": "Output",
           "propagation": 0,
           "bits": 1,

--- a/src/cells/gates.mjs
+++ b/src/cells/gates.mjs
@@ -6,64 +6,84 @@ import bigInt from 'big-integer';
 import * as help from '../help.mjs';
 import { Vector3vl } from '3vl';
 
-// Single-input gate model
-export const Gate11 = Gate.define('Gate11', {
+// base class for gates displayed using an external svg image
+export const GateSVG = Gate.define('GateSVG', {
+    /* default properties */
+    bits: 1,
+    
     size: { width: 60, height: 40 },
     attrs: {
-        '.body': { width: 60, height: 40 }
+        'image.body': { refWidth: 1, refHeight: 1 }
+    },
+    ports: {
+        groups: {
+            'in': { position: { name: 'left', args: { dx: 20 } }, attrs: { 'line.wire': { x2: -40 }, 'circle.port': { refX: -40 } }, z: -1 },
+            'out': { position: { name: 'right', args: { dx: -20 } }, attrs: { 'line.wire': { x2: 40 }, 'circle.port': { refX: 40 } }, z: -1 }
+        }
     }
 }, {
-    constructor: function(args) {
-        if (!args.bits) args.bits = 1;
-        this.markup = [
-            this.addWire(args, 'right', 0.5, { id: 'out', dir: 'out', bits: args.bits }),
-            this.addWire(args, 'left', 0.5, { id: 'in', dir: 'in', bits: args.bits }),
-            '<image class="body"/>',
-            '<text class="label"/>',
-        ].join('');
-        Gate.prototype.constructor.apply(this, arguments);
-    },
+    markup: Gate.prototype.markup.concat([{
+            tagName: 'image',
+            className: 'body'
+        }
+    ]),
     gateParams: Gate.prototype.gateParams.concat(['bits'])
+});
+
+// Single-input gate model
+export const Gate11 = GateSVG.define('Gate11', {}, {
+    initialize: function() {
+        GateSVG.prototype.initialize.apply(this, arguments);
+        
+        const bits = this.prop('bits');
+        
+        this.addPorts([
+            { id: 'in', group: 'in', dir: 'in', bits: bits },
+            { id: 'out', group: 'out', dir: 'out', bits: bits }
+        ]);
+        
+        this.on('change:bits', (_, bits) => {
+            this.setPortBits('in', bits);
+            this.setPortBits('out', bits);
+        });
+    }
 });
 
 // Two-input gate model
-export const Gate21 = Gate.define('Gate21', {
-    size: { width: 60, height: 40 },
-    attrs: {
-        '.body': { width: 60, height: 40 }
+export const Gate21 = GateSVG.define('Gate21', {}, {
+    initialize: function() {
+        GateSVG.prototype.initialize.apply(this, arguments);
+        
+        const bits = this.prop('bits');
+        this.addPorts([
+            { id: 'in1', group: 'in', dir: 'in', bits: bits },
+            { id: 'in2', group: 'in', dir: 'in', bits: bits },
+            { id: 'out', group: 'out', dir: 'out', bits: bits }
+        ]);
+        
+        this.on('change:bits', (_, bits) => {
+            this.setPortBits('in1', bits);
+            this.setPortBits('in2', bits);
+            this.setPortBits('out', bits);
+        });
     }
-}, {
-    constructor: function(args) {
-        if (!args.bits) args.bits = 1;
-        this.markup = [
-            this.addWire(args, 'right', 0.5, { id: 'out', dir: 'out', bits: args.bits }),
-            this.addWire(args, 'left', 0.3, { id: 'in1', dir: 'in', bits: args.bits }),
-            this.addWire(args, 'left', 0.7, { id: 'in2', dir: 'in', bits: args.bits }),
-            '<image class="body"/>',
-            '<text class="label"/>',
-        ].join('');
-        Gate.prototype.constructor.apply(this, arguments);
-    },
-    gateParams: Gate.prototype.gateParams.concat(['bits'])
 });
 
 // Reducing gate model
-export const GateReduce = Gate.define('GateReduce', {
-    size: { width: 60, height: 40 },
-    attrs: {
-        '.body': { width: 60, height: 40 }
+export const GateReduce = GateSVG.define('GateReduce', {}, {
+    initialize: function() {
+        GateSVG.prototype.initialize.apply(this, arguments);
+        const bits = this.prop('bits');
+        
+        this.addPorts([
+            { id: 'in', group: 'in', dir: 'in', bits: bits },
+            { id: 'out', group: 'out', dir: 'out', bits: 1 }
+        ]);
+        
+        this.on('change:bits', (_, bits) => {
+            this.setPortBits('in', bits);
+        });
     }
-}, {
-    constructor: function(args) {
-        if (!args.bits) args.bits = 1;
-        this.markup = [
-            this.addWire(args, 'right', 0.5, { id: 'out', dir: 'out', bits: 1 }),
-            this.addWire(args, 'left', 0.5, { id: 'in', dir: 'in', bits: args.bits }),
-            '<image class="body"/>',
-            '<text class="label"/>',
-        ].join('');
-        Gate.prototype.constructor.apply(this, arguments);
-    },
 });
 
 // Repeater (buffer) gate model

--- a/src/cells/subcircuit.mjs
+++ b/src/cells/subcircuit.mjs
@@ -1,35 +1,30 @@
 "use strict";
 
 import * as joint from 'jointjs';
-import { Gate, Box, BoxView } from './base';
+import { Box, BoxView } from './base';
 import { IO, Input, Output } from './io';
 import bigInt from 'big-integer';
 import * as help from '../help.mjs';
 
 // Subcircuit model -- embeds a circuit graph in an element
 export const Subcircuit = Box.define('Subcircuit', {
+    /* default properties */
     propagation: 0,
+    
     attrs: {
-        'path.wire' : { 'ref-y': .5, stroke: 'black' },
         'text.type': {
-            text: '', 'ref-x': 0.5, 'ref-y': -10,
-            'dominant-baseline': 'ideographic',
-            'text-anchor': 'middle',
-            fill: 'black'
-        },
-        '.tooltip': {
-            'ref-x': 0, 'ref-y': -30,
-            width: 80, height: 30
-        },
+            refX: .5, refY: -10,
+            textAnchor: 'middle', textVerticalAnchor: 'middle'
+        }
     }
 }, {
     initialize: function() {
-        this.listenTo(this, 'change:size', (model, size) => this.attr('.tooltip/width', size.width));
         Box.prototype.initialize.apply(this, arguments);
-    },
-    constructor: function(args) {
-        console.assert(args.graph instanceof joint.dia.Graph);
-        const graph = args.graph;
+        
+        this.bindAttrToProp('text.type/text', 'celltype');
+        
+        const graph = this.prop('graph');
+        console.assert(graph instanceof joint.dia.Graph);
         graph.set('subcircuit', this);
         const IOs = graph.getCells()
             .filter((cell) => cell instanceof IO);
@@ -44,39 +39,32 @@ export const Subcircuit = Box.define('Subcircuit', {
         outputs.sort(sortfun);
         const vcount = Math.max(inputs.length, outputs.length);
         const size = { width: 80, height: vcount*16+8 };
-        const markup = [];
-        const lblmarkup = [];
         const iomap = {};
-        _.set(args, ['attrs', 'text.type', 'text'], args.celltype);
-        args.inputSignals = args.inputSignals || {};
-        args.outputSignals = args.outputSignals || {};
         for (const [num, io] of inputs.entries()) {
-            markup.push(this.addLabelledWire(args, lblmarkup, 'left', num*16+12, { id: io.get('net'), dir: 'in', bits: io.get('bits') }));
-            args.inputSignals[io.get('net')] = io.get('outputSignals').out;
+            this.addPort({ id: io.get('net'), group: 'in', dir: 'in', bits: io.get('bits') }, { labelled: true });
+            this.prop(['inputSignals', io.get('net')], io.get('outputSignals').out);
         }
         for (const [num, io] of outputs.entries()) {
-            markup.push(this.addLabelledWire(args, lblmarkup, 'right', num*16+12, { id: io.get('net'), dir: 'out', bits: io.get('bits') }));
-            args.outputSignals[io.get('net')] = io.get('inputSignals').in;
+            this.addPort({ id: io.get('net'), group: 'out', dir: 'out', bits: io.get('bits') }, { labelled: true });
+            this.prop(['outputSignals', io.get('net')], io.get('inputSignals').in);
         }
-        markup.push('<rect class="body"/><text class="label"/><text class="type"/>');
-        markup.push(lblmarkup.join(''));
         for (const io of IOs) {
             iomap[io.get('net')] = io.get('id');
         }
-        markup.push('<foreignObject class="tooltip">');
-        markup.push('<body xmlns="http://www.w3.org/1999/xhtml">');
-        markup.push('<a class="zoom" href="">🔍</a>')
-        markup.push('</body></foreignObject>');
-        this.markup = markup.join('');
-        args.size = size;
-        args.attrs['rect.body'] = size;
-        args.circuitIOmap = iomap;
-        Gate.prototype.constructor.apply(this, arguments);
+        this.prop('size', size);
+        this.prop('circuitIOmap', iomap);
     },
-    gateParams: Box.prototype.gateParams.concat(['celltype'])
+    markup: Box.prototype.markup.concat([{
+            tagName: 'text',
+            className: 'type'
+        }
+    ], Box.prototype.markupZoom),
+    gateParams: Box.prototype.gateParams.concat(['celltype']),
+    unsupportedPropChanges: Box.prototype.unsupportedPropChanges.concat(['celltype'])
 });
 
 export const SubcircuitView = BoxView.extend({
+    autoResizeBox: true,
     events: {
         "click foreignObject.tooltip": "stopprop",
         "mousedown foreignObject.tooltip": "stopprop",

--- a/src/circuit.mjs
+++ b/src/circuit.mjs
@@ -122,7 +122,8 @@ export class HeadlessCircuit {
             }
         }
         function clearInput(end, gate) {
-            setInput(Vector3vl.xes(gate.ports[end.port].bits), end, gate);
+            var bits = gate.getPort(end.port).bits;
+            setInput(Vector3vl.xes(bits), end, gate);
         }
         this.listenTo(graph, 'change:target', function(wire, end) {
             const gate = graph.getCell(end.id);
@@ -149,7 +150,7 @@ export class HeadlessCircuit {
             const sgate = graph.getCell(strt.id);
             if (sgate && 'port' in strt) {
                 cell.set('signal', sgate.get('outputSignals')[strt.port]);
-                cell.set('bits', sgate.ports[strt.port].bits);
+                cell.set('bits', sgate.getPort(strt.port).bits);
             }
         });
         let laid_out = false;
@@ -167,8 +168,8 @@ export class HeadlessCircuit {
         }
         for (const conn of data.connectors) {
             graph.addCell(new this._cells.Wire({
-                source: {id: conn.from.id, port: conn.from.port},
-                target: {id: conn.to.id, port: conn.to.port},
+                source: {id: conn.from.id, port: conn.from.port, magnet: '.port'},
+                target: {id: conn.to.id, port: conn.to.port, magnet: '.port'},
                 netname: conn.name,
                 vertices: conn.vertices || []
             }));

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -90,24 +90,27 @@ export class Circuit extends HeadlessCircuit {
             el: elem,
             model: graph,
             width: 100, height: 100, gridSize: 5,
+            magnetThreshold: 'onleave',
             snapLinks: true,
             linkPinning: false,
+            markAvailable: true,
             defaultLink: new this._cells.Wire,
             cellViewNamespace: this._cells,
             validateConnection: function(vs, ms, vt, mt, e, vl) {
                 if (e === 'target') {
                     if (!mt) return false;
-                    const pt = vt.model.ports[mt.getAttribute('port')];
+                    const pt = vt.model.getPort(vt.findAttribute('port', mt));
                     if (typeof pt !== 'object' || pt.dir !== 'in' || pt.bits !== vl.model.get('bits'))
                         return false;
                     const link = this.model.getConnectedLinks(vt.model).find((l) =>
                         l.id !== vl.model.id &&
                         l.get('target').id === vt.model.id &&
-                        l.get('target').port === mt.getAttribute('port')
+                        l.get('target').port === vt.findAttribute('port', mt)
                     );
                     return !link;
                 } else if (e === 'source') { 
-                    const ps = vs.model.ports[ms.getAttribute('port')];
+                    if (!ms) return false;
+                    const ps = vs.model.getPort(vs.findAttribute('port', ms));
                     if (typeof ps !== 'object' || ps.dir !== 'out' || ps.bits !== vl.model.get('bits'))
                         return false;
                     return true;
@@ -125,6 +128,12 @@ export class Circuit extends HeadlessCircuit {
                 edgeSep: 0,
                 rankSep: 110,
                 rankDir: "LR",
+                setPosition: function(element, position) {
+                    element.setLayoutPosition(position);
+                },
+                exportElement: function(element) {
+                    return element.getLayoutSize();
+                },
                 dagre: dagre,
                 graphlib: graphlib
             });

--- a/src/style.css
+++ b/src/style.css
@@ -100,45 +100,26 @@
     cursor: crosshair;
 }
 
-.joint-element .body {
-    fill: white;
-    stroke: black;
-    transition: all 0.2s;
-}
-
-.djs .joint-element circle {
-    fill: #fff;
-    stroke: #7f8c8d;
-    stroke-opacity: 0.5;
-    stroke-width: 2px;
-}
-
-.djs .joint-element circle.live {
+.djs .joint-port-body.defined.live circle.port {
     stroke: #03c03c;
 }
 
-.djs .joint-element circle.low {
+.djs .joint-port-body.defined.low circle.port {
     stroke: #fc7c68;
 }
 
-.djs .joint-element circle.defined {
+.djs .joint-port-body.defined circle.port {
     stroke: #779ecb;
 }
 
 .djs .joint-element circle.led.live {
     fill: #03c03c;
+    stroke-width: 0;
 }
 
 .djs .joint-element circle.led.low {
     fill: #fc7c68;
-}
-
-.joint-element text {
-    font-size: 8pt;
-}
-
-.joint-element text.bits {
-    font-size: 7pt;
+    stroke-width: 0;
 }
 
 .joint-link.live > .connection {
@@ -629,10 +610,6 @@ g:hover > foreignObject.tooltip {
     box-sizing: border-box;
     background: white;
     padding: 5px;
-}
-
-.joint-element foreignObject.tooltip a.zoom {
-    cursor: pointer;
 }
 
 div.wire_hover {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,8 @@ const tests = [
     {name: 'sextium', title: 'Sextium III Processor'},
     {name: 'rom', title: 'Async ROM'},
     {name: 'ram', title: 'Simple RAM'},
-    {name: 'fsm', title: 'Finite State Machine'}
+    {name: 'fsm', title: 'Finite State Machine'},
+    {name: 'gates', title: 'All available gates'}
 ];
 
 module.exports = {


### PR DESCRIPTION
This PR tries to simplify some of the core codebase by moving to the standard jointJS solution for ports, markup, initialization and styling (via `attrs`) and by using a slightly clearer gate hierarchy.

I'm aware this branch contains a lot of changed lines, but most of the changes are connected and could not be committed separately (e.g. `addPort` only works after the `constructor` has already been called). I will try to give a quick overview over the changes here, feel free to ask if something is unclear.

Fixes #13 by switching to the [standard jointJS port](https://resources.jointjs.com/docs/jointjs/v3.0/joint.html#dia.Element.ports) solutions and a second move forwards towards #2 as several properties can now be changed including the `bits` and (at least some of) the gates should react on it properly.

- added a new `gates.json` file to `examples` to be able to see all ports in one paper
- `constructor` is replaced by `initialize` to be able to call [`addPort()`](https://resources.jointjs.com/docs/jointjs/v3.0/joint.html#dia.Element.prototype.addPort) while initializing gates (this is also the [recommended way for backbone.js](https://backbonejs.org/#Model-constructor))
- `this.listenTo(this, ...)` calls have been replaced by `this.on(...)` (see [backbone.js](https://backbonejs.org/#Events-listenTo))
- as ports are no longer needed to be added to the markup inside the constructor, `markup` is moved to be a prototype property as [recommended by jointJS](https://resources.jointjs.com/tutorial/custom-elements) and is thus shared between different instances of the same cell. Also `markup` has been migrated to use [JSON markup style](https://resources.jointjs.com/tutorials/joint/tutorials/custom-elements.html#markup) and is extended by sub-celltypes.
- the `attrs` are changed to use mostly *relative* dimensions (using jointJS `ref*` special attributes) to account for `size` changes automatically
- each cell type has been added respective default attributes s.th. every cell can be instantiated with no further arguments
- some styling which does not change during the cell lifetime has been moved from css to attrs
- each cell type claims now on which of its properties it currently does *not* react on changing (`unsupportedPropChanges`) and prints a warning to the console if one of these properties changes
- basic gates (e.g. arithmetic or logic ones) already successfully set their port bits on a `bits` property change (using `setPortBits()`, but still print a warning as connected wires are currently not handled

The last two points could be addressed in upcoming PRs.

Changes for specific celltypes:

- `Gate`:
  - added default port attributes for basic ports styling as well as default port markup
  - each `Gate` has two [port groups](https://resources.jointjs.com/docs/jointjs/v3.0/joint.html#groupssection) by default with specific styling (attrs): `in` (left) and `out` (right)
  - a `Gate` has always a `label` (markup and attrs) and reacts on `label` property change displaying the new label
  - `addWire` has been replaced by overriding [`addPort`](https://resources.jointjs.com/docs/jointjs/v3.0/joint.html#dia.Element.prototype.addPort) (the proper `inputSignals`/`outputSignals` are set within `resetPortBits`). Also `addLabelledWire` has be incorporated into `addPort` by always adding an optional `portlabel`.
  - consequently, `addPorts`, `removePort` and `removePorts` are also overridden
- `Box`:
  - is now a parent cell type for every cell that is displayed using a box and thus adds a `rect` to its markup with default styling (all `rects` now also use `strokeWidth: 2` - I'm aware this is a visual appearance change, but it looked nicer to me. If you object to this change, it would be quite easy to make it look again as before)
  - defines a common markup for a zoom tooltip and a path for the `clk` input symbol
  - the box resizing function has been generalized s.th. sub cell types are able to activate it (`autoResizeBox`) and influence the calculated width using `calculateBoxWidth`
- `Arith` is a new super cell type which defines common markup, attrs and slightly changed port groups (to cope with the circular shape) for all arithmetic cells
- `GateSVG` is another new super cell type with common markup, attrs and slightly changed port groups (to cope with the svg images which don't cover the whole rectangle) for all logic cells currently displayed using an external svg image
- `GenMux`
  - adds a new port group for the select input (on the top side)
  - the checkmark is now drawn using a path directly on the port instead of the mux' markup (the same `decor` is used to display the clock symbol on other cells' ports)

I would really appreciate if you could have a look at these changes, leave your comments, perhaps find problems or propose further changes.
