### PR TITLE
Polyfill ResizeObserver for older browsers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11811,6 +11811,11 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
     "resolve": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "jointjs": "^3.1.1",
     "jquery": "^3.4.1",
     "jquery-ui": "^1.12.1",
+    "resize-observer-polyfill": "^1.5.1",
     "wavecanvas": "^0.1.2"
   },
   "homepage": "https://github.com/tilk/digitaljs",

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -15,6 +15,11 @@ import { HeadlessCircuit, getCellType } from './circuit.mjs';
 import { MonitorView, Monitor } from './monitor.mjs';
 import './style.css';
 
+// polyfill ResizeObserver for e.g. Firefox ESR 68.8
+// this line and the node-module might be removed as soon as ResizeObserver is widely supported
+// see https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver#Browser_compatibility
+import ResizeObserver from 'resize-observer-polyfill';
+
 export { HeadlessCircuit, getCellType, cells, MonitorView, Monitor };
 
 export class Circuit extends HeadlessCircuit {
@@ -78,7 +83,8 @@ export class Circuit extends HeadlessCircuit {
             if (div.height() > maxHeight())
                 div.dialog("option", "height", maxHeight());
         }
-        const observer = new ResizeObserver(fixSize).observe(div.get(0));
+        const observer = new ResizeObserver(fixSize);
+        observer.observe(div.get(0));
         div.dialog({
             width: 'auto',
             height: 'auto',


### PR DESCRIPTION
Fixes #21. Roll-back is as easy as removing the node dependency and the line in `index.js`.

Also fixes an `undefined` variable error by splitting a line in two.