### PR TITLE
Move CSS styling to Javascript

### DIFF
--- a/src/cells/arith.mjs
+++ b/src/cells/arith.mjs
@@ -10,8 +10,8 @@ import { Vector3vl } from '3vl';
 export const Arith = Gate.define('Arith', {
     size: { width: 40, height: 40 },
     attrs: {
-        'circle.body': { refR: 0.5, refCx: 0.5, refCy: 0.5 },
-        'text.oper': {
+        body: { refR: 0.5, refCx: 0.5, refCy: 0.5 },
+        oper: {
             refX: .5, refY: .5,
             textAnchor: 'middle', textVerticalAnchor: 'middle',
             fontSize: '12pt'
@@ -19,17 +19,19 @@ export const Arith = Gate.define('Arith', {
     },
     ports: {
         groups: {
-            'in': { position: { name: 'left', args: { dx: 10 } }, attrs: { 'line.wire': { x2: -35 }, port: { refX: -35 } }, z: -1 },
-            'out': { position: { name: 'right', args: { dx: -10 } }, attrs: { 'line.wire': { x2: 35 }, port: { refX: 35 } }, z: -1 }
+            'in': { position: { name: 'left', args: { dx: 10 } }, attrs: { wire: { x2: -35 }, port: { refX: -35 } }, z: -1 },
+            'out': { position: { name: 'right', args: { dx: -10 } }, attrs: { wire: { x2: 35 }, port: { refX: 35 } }, z: -1 }
         }
     }
 }, {
     markup: Gate.prototype.markup.concat([{
             tagName: 'circle',
-            className: 'body'
+            className: 'body',
+            selector: 'body'
         }, {
             tagName: 'text',
-            className: 'oper'
+            className: 'oper',
+            selector: 'oper'
         }
     ]),
     gateParams: Gate.prototype.gateParams.concat(['bits', 'signed']),
@@ -190,7 +192,7 @@ export const EqCompare = Compare.define('EqCompare', {}, {
 // Negation
 export const Negation = Arith11.define('Negation', {
     attrs: {
-        'text.oper': { text: '-' }
+        oper: { text: '-' }
     }
 }, {
     arithop: i => bigInt.zero.minus(i)
@@ -200,7 +202,7 @@ export const NegationView = GateView;
 // Unary plus
 export const UnaryPlus = Arith11.define('UnaryPlus', {
     attrs: {
-        'text.oper': { text: '+' }
+        oper: { text: '+' }
     }
 }, {
     arithop: i => i
@@ -210,7 +212,7 @@ export const UnaryPlusView = GateView;
 // Addition
 export const Addition = Arith21.define('Addition', {
     attrs: {
-        'text.oper': { text: '+' }
+        oper: { text: '+' }
     }
 }, {
     arithop: (i, j) => i.plus(j)
@@ -220,7 +222,7 @@ export const AdditionView = GateView;
 // Subtraction
 export const Subtraction = Arith21.define('Subtraction', {
     attrs: {
-        'text.oper': { text: '-' }
+        oper: { text: '-' }
     }
 }, {
     arithop: (i, j) => i.minus(j)
@@ -230,7 +232,7 @@ export const SubtractionView = GateView;
 // Multiplication
 export const Multiplication = Arith21.define('Multiplication', {
     attrs: {
-        'text.oper': { text: '×' }
+        oper: { text: '×' }
     }
 }, {
     arithop: (i, j) => i.multiply(j)
@@ -240,7 +242,7 @@ export const MultiplicationView = GateView;
 // Division
 export const Division = Arith21.define('Division', {
     attrs: {
-        'text.oper': { text: '÷' }
+        oper: { text: '÷' }
     }
 }, {
     arithop: (i, j) => j.isZero() ? i : i.divide(j) // as in IEEE Verilog
@@ -250,7 +252,7 @@ export const DivisionView = GateView;
 // Modulo
 export const Modulo = Arith21.define('Modulo', {
     attrs: {
-        'text.oper': { text: '%' }
+        oper: { text: '%' }
     }
 }, {
     arithop: (i, j) => j.isZero() ? i : i.mod(j) // as in IEEE Verilog
@@ -260,7 +262,7 @@ export const ModuloView = GateView;
 // Power
 export const Power = Arith21.define('Power', {
     attrs: {
-        'text.oper': { text: '**' }
+        oper: { text: '**' }
     }
 }, {
     arithop: (i, j) => i.pow(j)
@@ -270,7 +272,7 @@ export const PowerView = GateView;
 // Shift left operator
 export const ShiftLeft = Shift.define('ShiftLeft', {
     attrs: {
-        'text.oper': { text: '≪' }
+        oper: { text: '≪' }
     }
 }, {
     shiftdir: -1
@@ -280,7 +282,7 @@ export const ShiftLeftView = GateView;
 // Shift right operator
 export const ShiftRight = Shift.define('ShiftRight', {
     attrs: {
-        'text.oper': { text: '≫' }
+        oper: { text: '≫' }
     }
 }, {
     shiftdir: 1
@@ -290,7 +292,7 @@ export const ShiftRightView = GateView;
 // Less than operator
 export const Lt = Compare.define('Lt', {
     attrs: {
-        'text.oper': { text: '<' }
+        oper: { text: '<' }
     }
 }, {
     arithcomp: (i, j) => i.lt(j)
@@ -300,7 +302,7 @@ export const LtView = GateView;
 // Less or equal operator
 export const Le = Compare.define('Le', {
     attrs: {
-        'text.oper': { text: '≤' }
+        oper: { text: '≤' }
     }
 }, {
     arithcomp: (i, j) => i.leq(j)
@@ -310,7 +312,7 @@ export const LeView = GateView;
 // Greater than operator
 export const Gt = Compare.define('Gt', {
     attrs: {
-        'text.oper': { text: '>' }
+        oper: { text: '>' }
     }
 }, {
     arithcomp: (i, j) => i.gt(j)
@@ -320,7 +322,7 @@ export const GtView = GateView;
 // Less than operator
 export const Ge = Compare.define('Ge', {
     attrs: {
-        'text.oper': { text: '≥' }
+        oper: { text: '≥' }
     }
 }, {
     arithcomp: (i, j) => i.geq(j)
@@ -330,7 +332,7 @@ export const GeView = GateView;
 // Equality operator
 export const Eq = EqCompare.define('Eq', {
     attrs: {
-        'text.oper': { text: '=' }
+        oper: { text: '=' }
     }
 }, {
     bincomp: (i, j) => i.xnor(j).reduceAnd()
@@ -340,7 +342,7 @@ export const EqView = GateView;
 // Nonequality operator
 export const Ne = EqCompare.define('Ne', {
     attrs: {
-        'text.oper': { text: '≠' }
+        oper: { text: '≠' }
     }
 }, {
     bincomp: (i, j) => i.xor(j).reduceOr()

--- a/src/cells/base.mjs
+++ b/src/cells/base.mjs
@@ -7,7 +7,7 @@ import { display3vl } from '../help.mjs';
 import { Vector3vl } from '3vl';
 
 export const portGroupAttrs = {
-    'line.wire': {
+    wire: {
         stroke: '#4B4F6A',
         x1: 0, y1: 0,
         x2: undefined, y2: 0
@@ -20,17 +20,17 @@ export const portGroupAttrs = {
         strokeWidth: 2,
         strokeOpacity: 0.5
     },
-    'text.bits': {
+    bits: {
         ref: 'port',
         fill: 'black',
         fontSize: '7pt'
     },
-    'text.iolabel': {
+    iolabel: {
         textVerticalAnchor: 'middle',
         fill: 'black',
         fontSize: '8pt'
     },
-    'path.decor': {
+    decor: {
         stroke: 'black',
         fill: 'transparent',
         d: undefined
@@ -48,12 +48,12 @@ export const Gate = joint.shapes.basic.Generic.define('Gate', {
     outputSignals: {},
     attrs: {
         '.': { magnet: false },
-        '.body': { stroke: 'black', strokeWidth: 2 },
+        body: { stroke: 'black', strokeWidth: 2 },
         'text': {
             fontSize: '8pt',
             fill: 'black'
         },
-        'text.label': {
+        label: {
             refX: .5, refDy: 3,
             textAnchor: 'middle'
         }
@@ -63,19 +63,19 @@ export const Gate = joint.shapes.basic.Generic.define('Gate', {
             'in': {
                 position: 'left',
                 attrs: _.merge({}, portGroupAttrs, {
-                    'line.wire': { x2: -25 },
+                    wire: { x2: -25 },
                     port: { magnet: 'passive', refX: -25 },
-                    'text.bits': { refDx: 1, refY: -3, textAnchor: 'start' },
-                    'text.iolabel': { refX: 5, textAnchor: 'start' }
+                    bits: { refDx: 1, refY: -3, textAnchor: 'start' },
+                    iolabel: { refX: 5, textAnchor: 'start' }
                 })
             },
             'out': {
                 position: 'right',
                 attrs: _.merge({}, portGroupAttrs, {
-                    'line.wire': { x2: 25 },
+                    wire: { x2: 25 },
                     port: { magnet: true, refX: 25 },
-                    'text.bits': { refX: -1, refY: -3, textAnchor: 'end' },
-                    'text.iolabel': { refX: -5, textAnchor: 'end' }
+                    bits: { refX: -1, refY: -3, textAnchor: 'end' },
+                    iolabel: { refX: -5, textAnchor: 'end' }
                 })
             }
         }
@@ -95,7 +95,7 @@ export const Gate = joint.shapes.basic.Generic.define('Gate', {
         
         joint.shapes.basic.Generic.prototype.initialize.apply(this, arguments);
         
-        this.bindAttrToProp('text.label/text', 'label');
+        this.bindAttrToProp('label/text', 'label');
         if (this.unsupportedPropChanges.length > 0) {
             this.on(this.unsupportedPropChanges.map(prop => 'change:'+prop).join(' '), function(model, _, opt) {
                 if (opt.init) return;
@@ -118,7 +118,7 @@ export const Gate = joint.shapes.basic.Generic.define('Gate', {
             console.assert(port.bits > 0);
             
             port.attrs = {};
-            port.attrs['text.bits'] = { text: this.getBitsText(port.bits) }
+            port.attrs['bits'] = { text: this.getBitsText(port.bits) }
             if (port.labelled) {
                 const iolabel = { text: 'portlabel' in port ? port.portlabel : port.id };
                 if (port.polarity === false)
@@ -127,10 +127,10 @@ export const Gate = joint.shapes.basic.Generic.define('Gate', {
                     console.assert(port.group == 'in');
                     iolabel['refX'] = 10;
                 }
-                port.attrs['text.iolabel'] = iolabel;
+                port.attrs['iolabel'] = iolabel;
             }
             if (port.decor) {
-                port.attrs['path.decor'] = { d: port.decor };
+                port.attrs['decor'] = { d: port.decor };
             }
         }
     },
@@ -142,7 +142,7 @@ export const Gate = joint.shapes.basic.Generic.define('Gate', {
                 return port.id && port.id === portid;
             });
             port.bits = bits;
-            port.attrs['text.bits'].text = this.getBitsText(bits);
+            port.attrs['bits'].text = this.getBitsText(bits);
             
             const signame = port.dir === 'in' ? 'inputSignals' : 'outputSignals';
             const signals = this.get(signame);
@@ -210,25 +210,30 @@ export const Gate = joint.shapes.basic.Generic.define('Gate', {
     },
     portMarkup: [{
         tagName: 'line',
-        className: 'wire'
+        className: 'wire',
+        selector: 'wire'
     }, {
         tagName: 'circle',
         className: 'port',
         selector: 'port'
     }, {
         tagName: 'text',
-        className: 'bits'
+        className: 'bits',
+        selector: 'bits'
     }, {
         tagName: 'text',
-        className: 'iolabel'
+        className: 'iolabel',
+        selector: 'iolabel'
     }, {
         tagName: 'path',
-        className: 'decor'
+        className: 'decor',
+        selector: 'decor'
     }],
     //portLabelMarkup: null, //todo: see https://github.com/clientIO/joint/issues/1278
     markup: [{
         tagName: 'text',
-        className: 'label'
+        className: 'label',
+        selector: 'label'
     }],
     getGateParams: function(layout) {
         return _.cloneDeep(_.pick(this.attributes, this.gateParams.concat(layout ? this.gateLayoutParams : [])));
@@ -502,29 +507,31 @@ export const WireView = joint.dia.LinkView.extend({
 
 export const Box = Gate.define('Box', {
     attrs: {
-        'rect.body': { refWidth: 1, refHeight: 1 },
-        '.tooltip': { refX: 0, refY: -30, height: 30 }
+        body: { refWidth: 1, refHeight: 1 },
+        tooltip: { refX: 0, refY: -30, height: 30 }
     }
 }, {
     initialize: function(args) {
         Gate.prototype.initialize.apply(this, arguments);
         this.on('change:size', (_, size) => {
             if (size.width > this.tooltipMinWidth) {
-                this.attr('.tooltip', { refWidth: 1, width: null });
+                this.attr('tooltip', { refWidth: 1, width: null });
             } else {
-                this.attr('.tooltip', { refWidth: null, width: this.tooltipMinWidth });
+                this.attr('tooltip', { refWidth: null, width: this.tooltipMinWidth });
             }
         });
         this.trigger('change:size', this, this.prop('size'));
     },
     markup: Gate.prototype.markup.concat([{
             tagName: 'rect',
-            className: 'body'
+            className: 'body',
+            selector: 'body'
         }
     ]),
     markupZoom: [{
         tagName: 'foreignObject',
         className: 'tooltip',
+        selector: 'tooltip',
         children: [{
             tagName: 'body',
             namespaceURI: 'http://www.w3.org/1999/xhtml',

--- a/src/cells/bus.mjs
+++ b/src/cells/bus.mjs
@@ -13,7 +13,7 @@ export const BitExtend = Box.define('BitExtend', {
     propagation: 0,
     
     attrs: {
-        "text.value": {
+        value: {
             refX: .5, refY: .5,
             textAnchor: 'middle', textVerticalAnchor: 'middle'
         }
@@ -39,7 +39,8 @@ export const BitExtend = Box.define('BitExtend', {
     },
     markup: Box.prototype.markup.concat([{
             tagName: 'text',
-            className: 'value'
+            className: 'value',
+            selector: 'value'
         }
     ]),
     gateParams: Box.prototype.gateParams.concat(['extend'])
@@ -54,7 +55,7 @@ export const BitExtendView = BoxView.extend({
 
 export const ZeroExtend = BitExtend.define('ZeroExtend', {
     attrs: {
-        "text.value": { text: 'zero-extend' }
+        value: { text: 'zero-extend' }
     }
 }, {
     extbit: function(i) {
@@ -65,7 +66,7 @@ export const ZeroExtendView = BitExtendView;
 
 export const SignExtend = BitExtend.define('SignExtend', {
     attrs: {
-        "text.value": { text: 'sign-extend' }
+        value: { text: 'sign-extend' }
     }
 }, {
     extbit: function(i) {

--- a/src/cells/gates.mjs
+++ b/src/cells/gates.mjs
@@ -14,8 +14,8 @@ const xor_arc_path = "M6.8 2.8L10 6.7S14.2 12 14.2 20 10 33.3 10 33.3l-3.2 3.9H1
 const xor_arc_path_markup = {
     tagName: 'path',
     attributes: {
-        fill: "#000",
-        d: xor_arc_path
+        'fill': "#000",
+        'd': xor_arc_path
     }
 };
 
@@ -23,9 +23,11 @@ const neg_markup = {
     tagName: 'circle',
     className: 'body',
     attributes: {
-        cx: 56,
-        cy: 20,
-        r: 4
+        'stroke': "#000",
+        'stroke-width': '2px',
+        'cx': 56,
+        'cy': 20,
+        'r': 4
     }
 };
 
@@ -37,14 +39,15 @@ export const GateSVG = Gate.define('GateSVG', {
     size: { width: 60, height: 40 },
     ports: {
         groups: {
-            'in': { position: { name: 'left', args: { dx: 20 } }, attrs: { 'line.wire': { x2: -40 }, port: { refX: -40 } }, z: -1 },
-            'out': { position: { name: 'right', args: { dx: -20 } }, attrs: { 'line.wire': { x2: 40 }, port: { refX: 40 } }, z: -1 }
+            'in': { position: { name: 'left', args: { dx: 20 } }, attrs: { wire: { x2: -40 }, port: { refX: -40 } }, z: -1 },
+            'out': { position: { name: 'right', args: { dx: -20 } }, attrs: { wire: { x2: 40 }, port: { refX: 40 } }, z: -1 }
         }
     }
 }, {
     markup: Gate.prototype.markup.concat([{
             tagName: 'path',
-            className: 'body gate'
+            className: 'body gate',
+            selector: 'body'
         }
     ]),
     gateParams: Gate.prototype.gateParams.concat(['bits'])
@@ -104,7 +107,7 @@ export const GateReduce = GateSVG.define('GateReduce', {}, {
 
 // Repeater (buffer) gate model
 export const Repeater = Gate11.define('Repeater', {
-    attrs: { 'path.gate': { d: buf_path }}
+    attrs: { body: { d: buf_path }}
 }, {
     operation: function(data) {
         return { out: data.in };
@@ -114,7 +117,7 @@ export const RepeaterView = GateView;
 
 // Not gate model
 export const Not = Gate11.define('Not', {
-    attrs: { 'path.gate': { d: buf_path }}
+    attrs: { body: { d: buf_path }}
 }, {
     operation: function(data) {
         return { out: data.in.not() };
@@ -125,7 +128,7 @@ export const NotView = GateView;
 
 // Or gate model
 export const Or = Gate21.define('Or', {
-    attrs: { 'path.gate': { d: or_path }}
+    attrs: { body: { d: or_path }}
 }, {
     operation: function(data) {
         return { out: data.in1.or(data.in2) };
@@ -135,7 +138,7 @@ export const OrView = GateView;
 
 // And gate model
 export const And = Gate21.define('And', {
-    attrs: { 'path.gate': { d: and_path }}
+    attrs: { body: { d: and_path }}
 }, {
     operation: function(data) {
         return { out: data.in1.and(data.in2) };
@@ -145,7 +148,7 @@ export const AndView = GateView;
 
 // Nor gate model
 export const Nor = Gate21.define('Nor', {
-    attrs: { 'path.gate': { d: or_path }}
+    attrs: { body: { d: or_path }}
 }, {
     operation: function(data) {
         return { out: data.in1.nor(data.in2) };
@@ -156,7 +159,7 @@ export const NorView = GateView;
 
 // Nand gate model
 export const Nand = Gate21.define('Nand', {
-    attrs: { 'path.gate': { d: and_path }}
+    attrs: { body: { d: and_path }}
 }, {
     operation: function(data) {
         return { out: data.in1.nand(data.in2) };
@@ -167,7 +170,7 @@ export const NandView = GateView;
 
 // Xor gate model
 export const Xor = Gate21.define('Xor', {
-    attrs: { 'path.gate': { d: or_path }}
+    attrs: { body: { d: or_path }}
 }, {
     operation: function(data) {
         return { out: data.in1.xor(data.in2) };
@@ -178,7 +181,7 @@ export const XorView = GateView;
 
 // Xnor gate model
 export const Xnor = Gate21.define('Xnor', {
-    attrs: { 'path.gate': { d: or_path }}
+    attrs: { body: { d: or_path }}
 }, {
     operation: function(data) {
         return { out: data.in1.xnor(data.in2) };
@@ -189,7 +192,7 @@ export const XnorView = GateView;
 
 // Reducing Or gate model
 export const OrReduce = GateReduce.define('OrReduce', {
-    attrs: { 'path.gate': { d: or_path }}
+    attrs: { body: { d: or_path }}
 }, {
     operation: function(data) {
         return { out: data.in.reduceOr() };
@@ -199,7 +202,7 @@ export const OrReduceView = GateView;
 
 // Reducing Nor gate model
 export const NorReduce = GateReduce.define('NorReduce', {
-    attrs: { 'path.gate': { d: or_path }}
+    attrs: { body: { d: or_path }}
 }, {
     operation: function(data) {
         return { out: data.in.reduceNor() };
@@ -210,7 +213,7 @@ export const NorReduceView = GateView;
 
 // Reducing And gate model
 export const AndReduce = GateReduce.define('AndReduce', {
-    attrs: { 'path.gate': { d: and_path }}
+    attrs: { body: { d: and_path }}
 }, {
     operation: function(data) {
         return { out: data.in.reduceAnd() };
@@ -220,7 +223,7 @@ export const AndReduceView = GateView;
 
 // Reducing Nand gate model
 export const NandReduce = GateReduce.define('NandReduce', {
-    attrs: { 'path.gate': { d: and_path }}
+    attrs: { body: { d: and_path }}
 }, {
     operation: function(data) {
         return { out: data.in.reduceNand() };
@@ -231,7 +234,7 @@ export const NandReduceView = GateView;
 
 // Reducing Xor gate model
 export const XorReduce = GateReduce.define('XorReduce', {
-    attrs: { 'path.gate': { d: or_path }}
+    attrs: { body: { d: or_path }}
 }, {
     operation: function(data) {
         return { out: data.in.reduceXor() };
@@ -242,7 +245,7 @@ export const XorReduceView = GateView;
 
 // Reducing Xnor gate model
 export const XnorReduce = GateReduce.define('XnorReduce', {
-    attrs: { 'path.gate': { d: or_path }}
+    attrs: { body: { d: or_path }}
 }, {
     operation: function(data) {
         return { out: data.in.reduceXnor() };

--- a/src/cells/io.mjs
+++ b/src/cells/io.mjs
@@ -27,6 +27,7 @@ export const NumBase = Box.define('NumBase', {
     markup: Box.prototype.markup.concat([{
             tagName: 'foreignObject',
             className: 'tooltip',
+            selector: 'tooltip',
             children: [{
                 tagName: 'body',
                 namespaceURI: 'http://www.w3.org/1999/xhtml',
@@ -92,7 +93,7 @@ export const NumDisplay = NumBase.define('NumDisplay', {
     propagation: 0,
 
     attrs: {
-        'text.value': { 
+        value: { 
             refX: .5, refY: .5,
             textVerticalAnchor: 'middle'
         },
@@ -117,7 +118,8 @@ export const NumDisplay = NumBase.define('NumDisplay', {
     },
     markup: NumBase.prototype.markup.concat([{
             tagName: 'text',
-            className: 'value numvalue'
+            className: 'value numvalue',
+            selector: 'value'
         }
     ]),
     getLogicValue: function() {
@@ -225,7 +227,7 @@ export const Lamp = Box.define('Lamp', {
 
     size: { width: 30, height: 30 },
     attrs: {
-        '.led': {
+        led: {
             refX: .5, refY: .5,
             refR: .35,
             stroke: 'black'
@@ -234,7 +236,8 @@ export const Lamp = Box.define('Lamp', {
 }, {
     markup: Box.prototype.markup.concat([{
             tagName: 'circle',
-            className: 'led'
+            className: 'led',
+            selector: 'led',
         }
     ]),
     getLogicValue: function() {
@@ -273,7 +276,7 @@ export const Button = Box.define('Button', {
 
     size: { width: 30, height: 30 },
     attrs: {
-        '.btnface': { 
+        btnface: { 
             stroke: 'black', strokeWidth: 2,
             refX: .2, refY: .2,
             refHeight: .6, refWidth: .6,
@@ -286,7 +289,8 @@ export const Button = Box.define('Button', {
     },
     markup: Box.prototype.markup.concat([{
             tagName: 'rect',
-            className: 'btnface'
+            className: 'btnface',
+            selector: 'btnface'
         }
     ]),
     setLogicValue: function(sig) {
@@ -324,7 +328,7 @@ export const IO = Box.define('IO', {
     propagation: 0,
 
     attrs: {
-        'text.ioname': {
+        ioname: {
             refX: .5, refY: .5,
             textAnchor: 'middle', textVerticalAnchor: 'middle',
             fontWeight: 'bold',
@@ -349,7 +353,8 @@ export const IO = Box.define('IO', {
     },
     markup: Box.prototype.markup.concat([{
             tagName: 'text',
-            className: 'ioname'
+            className: 'ioname',
+            selector: 'ioname'
         }
     ]),
     gateParams: Box.prototype.gateParams.concat(['bits','net'])
@@ -389,7 +394,7 @@ export const Constant = NumBase.define('Constant', {
     propagation: 0,
 
     attrs: {
-        'text.value': {
+        value: {
             refX: .5, refY: .5,
             textVerticalAnchor: 'middle'
         }
@@ -423,7 +428,8 @@ export const Constant = NumBase.define('Constant', {
     },
     markup: NumBase.prototype.markup.concat([{
             tagName: 'text',
-            className: 'value numvalue'
+            className: 'value numvalue',
+            selector: 'value'
         }
     ]),
     gateParams: NumBase.prototype.gateParams.concat(['constant']),
@@ -461,6 +467,7 @@ export const Clock = Box.define('Clock', {
         }, {
             tagName: 'foreignObject',
             className: 'tooltip',
+            selector: 'tooltip',
             children: [{
                 tagName: 'body',
                 namespaceURI: 'http://www.w3.org/1999/xhtml',

--- a/src/cells/io.mjs
+++ b/src/cells/io.mjs
@@ -42,8 +42,8 @@ export const NumBase = Box.define('NumBase', {
 });
 export const NumBaseView = BoxView.extend({
     presentationAttributes: BoxView.addPresentationAttributes({
-        bits: 'flag:bits',
-        numbase: 'flag:numbase'
+        bits: 'BITS',
+        numbase: 'NUMBASE'
     }),
     autoResizeBox: true,
     events: {
@@ -65,9 +65,9 @@ export const NumBaseView = BoxView.extend({
     },
     confirmUpdate(flags) {
         BoxView.prototype.confirmUpdate.apply(this, arguments);
-        if (this.hasFlag(flags, 'flag:bits') || this.hasFlag(flags, 'RENDER'))
+        if (this.hasFlag(flags, 'BITS') || this.hasFlag(flags, 'RENDER'))
             this.makeNumBaseSelector();
-        if (this.hasFlag(flags, 'flag:numbase'))
+        if (this.hasFlag(flags, 'NUMBASE'))
             this.updateNumBaseSelector();
     },
     makeNumBaseSelector() {
@@ -184,7 +184,7 @@ export const NumEntry = NumBase.define('NumEntry', {
 });
 export const NumEntryView = NumBaseView.extend({
     presentationAttributes: NumBaseView.addPresentationAttributes({
-        buttonState: 'flag:buttonState'
+        buttonState: 'SIGNAL'
     }),
     events: _.merge({
         "click input": "stopprop",
@@ -197,8 +197,8 @@ export const NumEntryView = NumBaseView.extend({
     },
     confirmUpdate(flags) {
         NumBaseView.prototype.confirmUpdate.apply(this, arguments);
-        if (this.hasFlag(flags, 'flag:buttonState') ||
-            this.hasFlag(flags, 'flag:numbase')) this.settext();
+        if (this.hasFlag(flags, 'SIGNAL') ||
+            this.hasFlag(flags, 'NUMBASE')) this.settext();
     },
     settext() {
         this.$('input').val(display3vl.show(this.model.get('numbase'), this.model.get('buttonState')));
@@ -230,14 +230,14 @@ export const Lamp = Box.define('Lamp', {
         led: {
             refX: .5, refY: .5,
             refR: .35,
-            stroke: 'black'
+            fill: '#bfc5c6'
         }
     }
 }, {
     markup: Box.prototype.markup.concat([{
             tagName: 'circle',
             className: 'led',
-            selector: 'led',
+            selector: 'led'
         }
     ]),
     getLogicValue: function() {
@@ -245,19 +245,30 @@ export const Lamp = Box.define('Lamp', {
     }
 });
 export const LampView = BoxView.extend({
+    attrs: {
+        signal: {
+            high: { led: { 'fill': '#03c03c' } },
+            low: { led: { 'fill': '#fc7c68' } },
+            undef: { led: { 'fill': '#bfc5c6' } }
+        }
+    },
     confirmUpdate(flags) {
         BoxView.prototype.confirmUpdate.apply(this, arguments);
-        if (this.hasFlag(flags, 'flag:inputSignals')) {
-            this.updateLamp(this.model.get('inputSignals'));
+        if (this.hasFlag(flags, 'SIGNAL')) {
+            this.updateLamp();
         };
     },
-    updateLamp(signal) {
-        this.$(".led").toggleClass('live', signal.in.isHigh);
-        this.$(".led").toggleClass('low', signal.in.isLow);
+    updateLamp() {
+        const signal = this.model.get('inputSignals').in;
+        const attrs = this.attrs.signal[
+            signal.isHigh ? 'high' :
+            signal.isLow ? 'low' : 'undef'
+        ];
+        this.applyAttrs(attrs);
     },
-    render() {
-        BoxView.prototype.render.apply(this, arguments);
-        this.updateLamp(this.model.get('inputSignals'));
+    update() {
+        BoxView.prototype.update.apply(this, arguments);
+        this.updateLamp();
     }
 });
 
@@ -298,18 +309,31 @@ export const Button = Box.define('Button', {
     }
 });
 export const ButtonView = BoxView.extend({
-    presentationAttributes: BoxView.addPresentationAttributes({
-        buttonState: 'flag:buttonState',
-    }),
-    initialize: function() {
-        BoxView.prototype.initialize.apply(this, arguments);
-        this.$(".btnface").toggleClass('live', this.model.get('buttonState'));
+    attrs: {
+        signal: {
+            high: { btnface: { 'fill': 'black' } },
+            low: { btnface: { 'fill': 'white' } }
+        }
     },
+    presentationAttributes: BoxView.addPresentationAttributes({
+        buttonState: 'SIGNAL',
+    }),
     confirmUpdate(flags) {
         BoxView.prototype.confirmUpdate.apply(this, arguments);
-        if (this.hasFlag(flags, 'flag:buttonState')) {
-            this.$(".btnface").toggleClass('live', this.model.get('buttonState'));
+        if (this.hasFlag(flags, 'SIGNAL')) {
+            this.updateButton();
         }
+    },
+    updateButton() {
+        const buttonState = this.model.get('buttonState');
+        const attrs = this.attrs.signal[
+            buttonState ? 'high' : 'low'
+        ];
+        this.applyAttrs(attrs);
+    },
+    update() {
+        BoxView.prototype.update.apply(this, arguments);
+        this.updateButton();
     },
     events: {
         "click .btnface": "activateButton",
@@ -317,7 +341,7 @@ export const ButtonView = BoxView.extend({
     },
     activateButton() {
         this.model.set('buttonState', !this.model.get('buttonState'));
-    },
+    }
 });
 
 // Input/output model
@@ -481,7 +505,7 @@ export const Clock = Box.define('Clock', {
 });
 export const ClockView = BoxView.extend({
     presentationAttributes: BoxView.addPresentationAttributes({
-        propagation: 'flag:propagation'
+        propagation: 'SIGNAL'
     }),
     events: {
         "click input": "stopprop",
@@ -495,7 +519,7 @@ export const ClockView = BoxView.extend({
     },
     confirmUpdate(flags) {
         BoxView.prototype.confirmUpdate.apply(this, arguments);
-        if (this.hasFlag(flags, 'flag:propagation')) this.updatePropagation();
+        if (this.hasFlag(flags, 'SIGNAL')) this.updatePropagation();
     },
     changePropagation(evt) {
         const val = evt.target.value;

--- a/src/cells/memory.mjs
+++ b/src/cells/memory.mjs
@@ -20,7 +20,7 @@ export const Memory = Box.define('Memory', {
     offset: 0,
     
     attrs: {
-        'path.portsplit': {
+        portsplit: {
             stroke: 'black', d: undefined
         }
     },
@@ -194,7 +194,8 @@ export const Memory = Box.define('Memory', {
     },
     markup: Box.prototype.markup.concat([{
             tagName: 'path',
-            className: 'portsplit'
+            className: 'portsplit',
+            selector: 'portsplit'
         }], Box.prototype.markupZoom),
     getGateParams: function() { 
         // hack to get memdata back

--- a/src/cells/mux.mjs
+++ b/src/cells/mux.mjs
@@ -92,7 +92,7 @@ export const GenMuxView = GateView.extend({
     },
     confirmUpdate(flags) {
         GateView.prototype.confirmUpdate.apply(this, arguments);
-        if (this.hasFlag(flags, 'flag:inputSignals')) {
+        if (this.hasFlag(flags, 'SIGNAL')) {
             this.updateMux(this.model.get('inputSignals'));
         }
     },

--- a/src/cells/mux.mjs
+++ b/src/cells/mux.mjs
@@ -18,9 +18,9 @@ export const GenMux = Gate.define('GenMux', {
             'in2': {
                 position: { name: 'top', args: { y: 5 } },
                 attrs: _.merge({}, portGroupAttrs, {
-                    'line.wire': { x2: 0, y2: -20 },
+                    wire: { x2: 0, y2: -20 },
                     port: { magnet: 'passive', refY: -20 },
-                    'text.bits': { refDx: -5, refDy: 2, textAnchor: 'start' }
+                    bits: { refDx: -5, refDy: 2, textAnchor: 'start' }
                 }),
                 z: -1
             }
@@ -52,7 +52,7 @@ export const GenMux = Gate.define('GenMux', {
         
         Gate.prototype.initialize.apply(this, arguments);
         
-        const drawBorder = (size) => this.attr(['polygon.body', 'points'], 
+        const drawBorder = (size) => this.attr(['body', 'points'], 
             [[0,0],[size.width,10],[size.width,size.height-10],[0,size.height]]
                 .map(x => x.join(',')).join(' '));
         drawBorder(this.get('size'));
@@ -78,7 +78,8 @@ export const GenMux = Gate.define('GenMux', {
     },
     markup: Gate.prototype.markup.concat([{
             tagName: 'polygon',
-            className: 'body'
+            className: 'body',
+            selector: 'body'
         }
     ]),
     gateParams: Gate.prototype.gateParams.concat(['bits']),

--- a/src/cells/subcircuit.mjs
+++ b/src/cells/subcircuit.mjs
@@ -12,7 +12,7 @@ export const Subcircuit = Box.define('Subcircuit', {
     propagation: 0,
 
     attrs: {
-        'text.type': {
+        type: {
             refX: .5, refY: -10,
             textAnchor: 'middle', textVerticalAnchor: 'middle'
         }
@@ -71,7 +71,8 @@ export const Subcircuit = Box.define('Subcircuit', {
     },
     markup: Box.prototype.markup.concat([{
             tagName: 'text',
-            className: 'type'
+            className: 'type',
+            selector: 'type'
         }
     ], Box.prototype.markupZoom),
     gateParams: Box.prototype.gateParams.concat(['celltype']),

--- a/src/style.css
+++ b/src/style.css
@@ -1,69 +1,8 @@
-.connection {
-    stroke: #999;
-}
-
 .joint-element .highlighted {
     outline: none;
     fill: #ecf0f1;
     stroke: #bdc3c7;
     cursor: crosshair;
-}
-
-.djs .joint-port-body.defined.live circle.port {
-    stroke: #03c03c;
-}
-
-.djs .joint-port-body.defined.low circle.port {
-    stroke: #fc7c68;
-}
-
-.djs .joint-port-body.defined circle.port {
-    stroke: #779ecb;
-}
-
-.djs .joint-element circle.led {
-    fill: #bfc5c6;
-    stroke-width: 0;
-}
-
-.djs .joint-element circle.led.live {
-    fill: #03c03c;
-}
-
-.djs .joint-element circle.led.low {
-    fill: #fc7c68;
-}
-
-.joint-link.live > .connection {
-    stroke: #03c03c;
-}
-
-.joint-link.low > .connection {
-    stroke: #fc7c68;
-}
-
-.joint-link.defined > .connection {
-    stroke: #779ecb;
-}
-
-.joint-link.bus > .connection {
-    stroke-width: 4px;
-}
-
-.joint-link .label > text {
-    font-size: 8pt;
-}
-
-.joint-element.live .body {
-    fill: #FEB662;
-    stroke: #CF9452;
-}
-
-.joint-element.live text {
-    fill: #ffffff;
-}
-.wire {
-    stroke: #4B4F6A;
 }
 
 .djs.fixed .joint-link {
@@ -191,10 +130,6 @@ body {
     font-family: 'verdana', sans-serif;
     font-weight: normal;
     font-style: normal;
-}
-
-.btnface.live {
-    fill: black;
 }
 
 .joint-element foreignObject {


### PR DESCRIPTION
This PR fixes #23 in two steps:
- switching from classNames to [jointjs selectors](https://resources.jointjs.com/tutorial/custom-elements#markup) for default `attrs` styling ("Selectors are important for the targeting of subelements by element attributes. Although providing a selector to identify a subelement is not strictly required, it makes JointJS noticeably faster because it can avoid querying the DOM."). For my experiments this change did not produce any noticeable performance boost, but at least it ran as fast as before.
- Instead of toggling corresponding classes in the `View`s, temporary attributes (such as "high", "low" or "bus") are directly set on the element for each value change. The temporary attributes might be adapted by overwriting `this.attrs` inside the View.

As already pointed out in #23, this means the SVG is now fully defined in Javascript and no further CSS styling is required.

Benchmarking of the changes gave the following result on the Horner example (with open `multiplier` of last `adder_multiplier` in the chain):
| Input change | before | after |
|--|--|--|
| `xxx` -> `00f` | 22s | 21s |
| `00f` -> `x` | 9s | 9s |

The changes did not noticeably alter the performance, most of the time indeed seems to be spent by the model calculation and not by updating the views.