### PR TITLE
Visual warning and prevent simulation on badly connected wires

### DIFF
--- a/examples/warnings.json
+++ b/examples/warnings.json
@@ -1,0 +1,95 @@
+{
+  "devices": {
+    "const1": {
+      "type": "Constant",
+      "constant": "00"
+    },
+    "not": {
+      "type": "Not",
+      "bits": 2
+    },
+    "lamp": {
+      "type": "Lamp"
+    },
+    "const2": {
+      "type": "Constant"
+    },
+    "subcir": {
+      "type": "Subcircuit",
+      "celltype": "subcir"
+    },
+    "display": {
+      "type": "NumDisplay",
+      "bits": 2
+    }
+  },
+  "connectors": [
+    {
+      "to": {
+        "id": "not",
+        "port": "in"
+      },
+      "from": {
+        "id": "const1",
+        "port": "out"
+      }
+    },
+    {
+      "to": {
+        "id": "lamp",
+        "port": "in"
+      },
+      "from": {
+        "id": "not",
+        "port": "out"
+      }
+    },
+    {
+      "to": {
+        "id": "subcir",
+        "port": "in"
+      },
+      "from": {
+        "id": "const2",
+        "port": "out"
+      }
+    },
+    {
+      "to": {
+        "id": "display",
+        "port": "in"
+      },
+      "from": {
+        "id": "subcir",
+        "port": "out"
+      }
+    }
+  ],
+  "subcircuits": {
+    "subcir": {
+      "devices": {
+        "in": {
+          "type": "Input",
+          "net": "in"
+        },
+        "out": {
+          "type": "Output",
+          "net": "out",
+          "bits": 2
+        }
+      },
+      "connectors": [
+        {
+          "to": {
+            "id": "out",
+            "port": "in"
+          },
+          "from": {
+            "id": "in",
+            "port": "out"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/cells/io.mjs
+++ b/src/cells/io.mjs
@@ -423,6 +423,11 @@ export const InputView = IOView;
 // Output model
 export const Output = IO.define('Output', {}, {
     io_dir: 'in',
+    changeInputSignals: function(sigs) {
+        const subcir = this.graph.get('subcircuit');
+        if (subcir == null) return; // not inside a subcircuit
+        subcir.setOutput(sigs.in, this.get('net'));
+    },
     getLogicValue: function() {
         return this.get('inputSignals').in;
     }

--- a/src/cells/subcircuit.mjs
+++ b/src/cells/subcircuit.mjs
@@ -57,6 +57,18 @@ export const Subcircuit = Box.define('Subcircuit', {
         
         Box.prototype.initialize.apply(this, arguments);
     },
+    setInput: function(sig, port) {
+        Box.prototype.setInput.apply(this, arguments);
+        const iomap = this.get('circuitIOmap');
+        const input = this.get('graph').getCell(iomap[port]);
+        console.assert(input.setLogicValue);
+        input.setLogicValue(sig);
+    },
+    setOutput: function(sig, port) {
+        const signals = _.clone(this.get('outputSignals'));
+        signals[port] = sig;
+        this.set('outputSignals', signals);
+    },
     //add offset of 10pt to account for the top label at layout time
     getLayoutSize: function() {
         const size = this.size();

--- a/src/cells/subcircuit.mjs
+++ b/src/cells/subcircuit.mjs
@@ -1,6 +1,7 @@
 "use strict";
 
 import * as joint from 'jointjs';
+import _ from 'lodash';
 import { Box, BoxView } from './base';
 import { IO, Input, Output } from './io';
 import bigInt from 'big-integer';
@@ -10,8 +11,13 @@ import * as help from '../help.mjs';
 export const Subcircuit = Box.define('Subcircuit', {
     /* default properties */
     propagation: 0,
+    warning: false,
 
     attrs: {
+        wrapper: {
+            refWidth: 1, refHeight: 1,
+            stroke: 'red', strokeWidth: 10
+        },
         type: {
             refX: .5, refY: -10,
             textAnchor: 'middle', textVerticalAnchor: 'middle'
@@ -54,6 +60,7 @@ export const Subcircuit = Box.define('Subcircuit', {
         this.set('inputSignals', inputSignals);
         this.set('outputSignals', outputSignals);
         this.get('ports').items = ports;
+        this.set('warning', graph._warnings > 0);
         
         Box.prototype.initialize.apply(this, arguments);
     },
@@ -81,7 +88,11 @@ export const Subcircuit = Box.define('Subcircuit', {
             y: position.y - position.height / 2 + 10
         });
     },
-    markup: Box.prototype.markup.concat([{
+    markup: [{
+            tagName: 'rect',
+            selector: 'wrapper'
+        }
+    ].concat(Box.prototype.markup, [{
             tagName: 'text',
             className: 'type',
             selector: 'type'
@@ -92,7 +103,33 @@ export const Subcircuit = Box.define('Subcircuit', {
 });
 
 export const SubcircuitView = BoxView.extend({
+    attrs: _.merge({}, BoxView.prototype.attrs, {
+        warning: {
+            warn: { wrapper: { 'stroke-opacity': '0.5' } },
+            none: { wrapper: { 'stroke-opacity': '0' } }
+        }
+    }),
     autoResizeBox: true,
+    presentationAttributes: BoxView.addPresentationAttributes({
+        warning: 'WARNING'
+    }),
+    confirmUpdate(flags) {
+        BoxView.prototype.confirmUpdate.apply(this, arguments);
+        if (this.hasFlag(flags, 'WARNING')) {
+            this.updateWarning();
+        }
+    },
+    updateWarning() {
+        const warning = this.model.get('warning');
+        const attrs = this.attrs.warning[
+            warning ? 'warn' : 'none'
+        ];
+        this.applyAttrs(attrs);
+    },
+    update() {
+        BoxView.prototype.update.apply(this, arguments);
+        this.updateWarning();
+    },
     events: {
         "click foreignObject.tooltip": "stopprop",
         "mousedown foreignObject.tooltip": "stopprop",

--- a/src/circuit.mjs
+++ b/src/circuit.mjs
@@ -87,84 +87,35 @@ export class HeadlessCircuit {
         const graph = new joint.dia.Graph();
         graph._display3vl = this._display3vl;
         this.listenTo(graph, 'change:buttonState', (gate, sig) => {
+            // buttonState is triggered for any user change on inputs
             this.enqueue(gate);
             this.trigger('userChange');
         });
-        this.listenTo(graph, 'change:signal', (wire, signal) => {
-            const gate = graph.getCell(wire.get('target').id);
-            if (gate) setInput(signal, wire.get('target'), gate);
-        });
         this.listenTo(graph, 'change:inputSignals', (gate, sigs) => {
-            // forward the change back from a subcircuit
-            if (gate instanceof this._cells.Output) {
-                const subcir = gate.graph.get('subcircuit');
-                if (subcir == null) return; // not in a subcircuit
-                console.assert(subcir instanceof this._cells.Subcircuit);
-                subcir.set('outputSignals', _.chain(subcir.get('outputSignals'))
-                    .clone().set(gate.get('net'), sigs.in).value());
+            if (gate.changeInputSignals) {
+                gate.changeInputSignals(sigs);
             } else this.enqueue(gate);
         });
         this.listenTo(graph, 'change:outputSignals', (gate, sigs) => {
-            _.chain(graph.getConnectedLinks(gate, {outbound: true}))
-                .groupBy((wire) => wire.get('source').port)
-                .forEach((wires, port) => 
-                    wires.forEach((wire) => wire.set('signal', sigs[port])))
-                .value();
+            gate.changeOutputSignals(sigs);
         });
-        this.listenTo(graph, 'change:source', (wire, end) => {
+        this.listenTo(graph, 'change:signal', (wire, signal) => {
+            wire.changeSignal(signal);
+        });
+        this.listenTo(graph, 'change:source', (wire, src) => {
             this._labelIndex = null; // TODO: update index
-            const gate = graph.getCell(end.id);
-            if (gate && 'port' in end) {
-                wire.set('signal', gate.get('outputSignals')[end.port]);
-            } else {
-                wire.set('signal', Vector3vl.xes(wire.get('bits')));
-            }
+            wire.changeSource(src);
         });
-        const setInput = (sig, end, gate) => {
-            gate.set('inputSignals', _.chain(gate.get('inputSignals'))
-                .clone().set(end.port, sig).value());
-            // forward the input change to a subcircuit
-            if (gate instanceof this._cells.Subcircuit) {
-                const iomap = gate.get('circuitIOmap');
-                const input = gate.get('graph').getCell(iomap[end.port]);
-                console.assert(input instanceof this._cells.Input);
-                input.set('outputSignals', { out: sig });
-            }
-        }
-        function clearInput(end, gate) {
-            var bits = gate.getPort(end.port).bits;
-            setInput(Vector3vl.xes(bits), end, gate);
-        }
         this.listenTo(graph, 'change:target', (wire, end) => {
             this._labelIndex = null; // TODO: update index
-            const gate = graph.getCell(end.id);
-            if (gate && 'port' in end) {
-                setInput(wire.get('signal'), end, gate);
-            } 
-            const pend = wire.previous('target');
-            const pgate = graph.getCell(pend.id);
-            if (pgate && 'port' in pend) {
-                clearInput(pend, pgate);
-            }
-        });
-        this.listenTo(graph, 'remove', (cell, coll, opt) => {
-            this._labelIndex = null; // TODO: update index
-            if (!cell.isLink()) return;
-            const end = cell.get('target');
-            const gate = graph.getCell(end.id);
-            if (gate && 'port' in end) {
-                clearInput(end, gate);
-            }
+            wire.changeTarget(end);
         });
         this.listenTo(graph, 'add', (cell, coll, opt) => {
             this._labelIndex = null; // TODO: update index
-            if (!cell.isLink()) return;
-            const strt = cell.get('source');
-            const sgate = graph.getCell(strt.id);
-            if (sgate && 'port' in strt) {
-                cell.set('signal', sgate.get('outputSignals')[strt.port]);
-                cell.set('bits', sgate.getPort(strt.port).bits);
-            }
+            if (cell.onAdd) cell.onAdd();
+        });
+        this.listenTo(graph, 'remove', (cell, coll, opt) => {
+            this._labelIndex = null; // TODO: update index
         });
         let laid_out = false;
         for (const devid in data.devices) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -32,12 +32,16 @@ export class Circuit extends HeadlessCircuit {
         this._idle = null;
     }
     start() {
+        if (this.hasWarnings())
+            return; //todo: print/show error
         this._interval = setInterval(() => {
             this.updateGates();
         }, this._interval_ms);
         this.trigger('changeRunning');
     }
     startFast() {
+        if (this.hasWarnings())
+            return; //todo: print/show error
         this._idle = requestIdleCallback((dd) => {
             while (dd.timeRemaining() > 0 && this.hasPendingEvents && this._idle !== null)
                 this.updateGatesNext();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,8 @@ const tests = [
     {name: 'ram', title: 'Simple RAM'},
     {name: 'fsm', title: 'Finite State Machine'},
     {name: 'gates', title: 'All available gates'},
-    {name: 'horner', title: 'Benchmark example'}
+    {name: 'horner', title: 'Benchmark example'},
+    {name: 'warnings', title: 'Warnings example'}
 ];
 
 module.exports = {


### PR DESCRIPTION
As discussed in #10, a visual warning is shown for invalid connections (not matching bit-sizes) on the wires directly and in case of subcircuits, on the subcircuit box too. For now, there is no additional message shown as a tooltip, but this could potentially be added in a second step later.

See the newly added `warnings.json` example:
![grafik](https://user-images.githubusercontent.com/18088991/87468920-ba950880-c61a-11ea-9fb4-efa76a54b187.png)

In case of warnings, the simulation will stop and prevent starting until all connections are valid.
The information is also accessible by code via `HeadlessCircuit.hasWarnings()`.

Also, I've moved some of the gate/wire update logic from the circuit level to the gates and wires themselves to better separate the code logically.