### PR TITLE
Fixes to change bits after initialization

### DIFF
--- a/examples/template.html
+++ b/examples/template.html
@@ -5,6 +5,10 @@
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body>
+    <div>
+        <button name="start" type="button">▶️</button>
+        <button name="stop" type="button">⏹️</button>
+    </div>
     <div id="paper">
     </div>
     <div>
@@ -21,6 +25,8 @@
     </div>
     <script>
       var circuit, monitor, monitorview, iopanel, paper;
+      var start = $('button[name=start]');
+      var stop = $('button[name=stop]');
       var papers = {};
       const fixed = function (fixed) {
         Object.values(papers).forEach(p => p.fixed(fixed));
@@ -38,6 +44,15 @@
             console.info('You can now access the doubly clicked gate as digitaljsCell in your WebBrowser console!');
           });
         });
+        circuit.on('changeRunning', () => {
+          if (circuit.running) {
+            start.prop('disabled', true);
+            stop.prop('disabled', false);
+          } else {
+            start.prop('disabled', false);
+            stop.prop('disabled', true);
+          }
+        });
         paper = circuit.displayOn($('#paper'));
         fixed($('input[name=fixed]').prop('checked'));
         circuit.on('remove:paper', function(paper) {
@@ -45,6 +60,8 @@
         });
         circuit.start();
       }
+      start.on('click', (e) => { circuit.start(); });
+      stop.on('click', (e) => { circuit.stop(); });
       $('button[name=json]').on('click', (e) => {
         monitorview.shutdown();
         iopanel.shutdown();

--- a/examples/template.html
+++ b/examples/template.html
@@ -21,24 +21,27 @@
     </div>
     <script>
       var circuit, monitor, monitorview, iopanel, paper;
-      var subpapers = {};
+      var papers = {};
       const fixed = function (fixed) {
-        paper.fixed(fixed);
-        Object.values(subpapers).forEach(p => p.fixed(fixed));
+        Object.values(papers).forEach(p => p.fixed(fixed));
       }
       const loadCircuit = function (json) {
         circuit = new digitaljs.Circuit(json);
         monitor = new digitaljs.Monitor(circuit);
         monitorview = new digitaljs.MonitorView({model: monitor, el: $('#monitor') });
         iopanel = new digitaljs.IOPanelView({model: circuit, el: $('#iopanel') });
+        circuit.on('new:paper', function(paper) {
+          paper.fixed($('input[name=fixed]').prop('checked'));
+          papers[paper.cid] = paper;
+          paper.on('element:pointerdblclick', (cellView) => {
+            window.digitaljsCell = cellView.model;
+            console.info('You can now access the doubly clicked gate as digitaljsCell in your WebBrowser console!');
+          });
+        });
         paper = circuit.displayOn($('#paper'));
         fixed($('input[name=fixed]').prop('checked'));
-        circuit.on('new:paper', function(subpaper) {
-          subpaper.fixed($('input[name=fixed]').prop('checked'));
-          subpapers[subpaper.cid] = subpaper;
-        });
-        circuit.on('remove:paper', function(subpaper) {
-          delete subpapers[subpaper.cid];
+        circuit.on('remove:paper', function(paper) {
+          delete papers[paper.cid];
         });
         circuit.start();
       }

--- a/src/cells/bus.mjs
+++ b/src/cells/bus.mjs
@@ -96,7 +96,7 @@ export const BusSlice = Box.define('BusSlice', {
         
         Box.prototype.initialize.apply(this, arguments);
         
-        this.on('change:extend', (_, extend) => {
+        this.on('change:slice', (_, slice) => {
             this.setPortsBits({ in: slice.total, out: slice.count });
         });
     },

--- a/src/circuit.mjs
+++ b/src/circuit.mjs
@@ -90,10 +90,13 @@ export class HeadlessCircuit {
         const graph = new joint.dia.Graph();
         graph._display3vl = this._display3vl;
         graph._warnings = 0;
-        this.listenTo(graph, 'change:buttonState', (gate, sig) => {
+        this.listenTo(graph, 'change:buttonState', (gate) => {
             // buttonState is triggered for any user change on inputs
             this.enqueue(gate);
             this.trigger('userChange');
+        });
+        this.listenTo(graph, 'change:constantCache', (gate) => {
+            this.enqueue(gate);
         });
         this.listenTo(graph, 'change:inputSignals', (gate, sigs) => {
             if (gate.changeInputSignals) {
@@ -118,6 +121,7 @@ export class HeadlessCircuit {
             if (cell.previous('warning') === warn)
                 return;
             graph._warnings += warn ? 1 : -1;
+            console.assert(graph._warnings >= 0);
 
             //todo: better handling for stopping simulation
             if (graph._warnings > 0 && this.running)


### PR DESCRIPTION
Another step towards #2 consisting of:
- better warning message for unsupported property changes (now also resets the value)
- refactoring some code in `Gate` to group `input`/`outputSignals` changes together
- enhanced template for examples to (re)start simulation and play around with gates on the console