### PR TITLE
Show zero bits line as undefined instead of high

### DIFF
--- a/src/cells/base.mjs
+++ b/src/cells/base.mjs
@@ -290,10 +290,11 @@ export const GateView = joint.dia.ElementView.extend({
             dir === 'out' ? this.model.get('outputSignals') :
             _.merge({}, this.model.get('inputSignals'), this.model.get('outputSignals'));
         for (const port in signals) {
+            const signal = signals[port];
             const attrs = this.attrs.signal[
-                signals[port].isHigh ? 'high' :
-                signals[port].isLow ? 'low' :
-                signals[port].isDefined ? 'def' : 'undef'
+                !signal.isDefined ? 'undef' :
+                signal.isHigh ? 'high' :
+                signal.isLow ? 'low' : 'def'
             ];
             this.applyPortAttrs(port, attrs);
         }
@@ -569,9 +570,9 @@ export const WireView = joint.dia.LinkView.extend({
     updateSignal() {
         const signal = this.model.get('signal');
         const attrs = this.attrs.signal[
+            !signal.isDefined ? 'undef' :
             signal.isHigh ? 'high' :
-            signal.isLow ? 'low' :
-            signal.isDefined ? 'def' : 'undef'
+            signal.isLow ? 'low' : 'def'
         ];
         this.applyAttrs(attrs);
     },


### PR DESCRIPTION
As bit lines of size zero are [by definition](https://github.com/tilk/js_3vl/blob/master/src/index.ts#L597) high *and* low, but undefined, this PR reorders the coloring to properly reflect zero bit lines as undefined.