### PR TITLE
Set undefined signal of correct bit width while instantiating NumEntry

### DIFF
--- a/src/cells/dff.mjs
+++ b/src/cells/dff.mjs
@@ -68,7 +68,7 @@ export const Dff = Box.define('Dff', {
         if ('clock' in polarity) {
             last_clk = this.last_clk;
             this.last_clk = data.clk.get(0);
-        };
+        }
         if ('enable' in polarity && data.en.get(0) != pol('enable'))
             return this.get('outputSignals');
         if ('arst' in polarity && data.arst.get(0) == pol('arst'))

--- a/src/cells/io.mjs
+++ b/src/cells/io.mjs
@@ -423,7 +423,7 @@ export const IOView = BoxView.extend({
 export const Input = IO.define('Input', {}, {
     io_dir: 'out',
     setLogicValue: function(sig) {
-        if (sig.bits != this.get('bits')) 
+        if (sig.bits != this.get('bits'))
             throw new Error("setLogicValue: wrong number of bits");
         this.set('outputSignals', { out: sig });
     }

--- a/src/cells/io.mjs
+++ b/src/cells/io.mjs
@@ -161,6 +161,7 @@ export const NumEntry = NumBase.define('NumEntry', {
         this.get('ports').items = [
             { id: 'out', group: 'out', dir: 'out', bits: bits }
         ];
+        this.setLogicValue(Vector3vl.xes(bits));
         
         NumBase.prototype.initialize.apply(this, arguments);
         


### PR DESCRIPTION
Fixes a bug introduced with #31.