### PR TITLE
Rename internal methods and fields to start with underscore

### DIFF
--- a/src/cells/arith.mjs
+++ b/src/cells/arith.mjs
@@ -34,8 +34,8 @@ export const Arith = Gate.define('Arith', {
             selector: 'oper'
         }
     ]),
-    gateParams: Gate.prototype.gateParams.concat(['bits', 'signed']),
-    unsupportedPropChanges: Gate.prototype.unsupportedPropChanges.concat(['signed'])
+    _gateParams: Gate.prototype._gateParams.concat(['bits', 'signed']),
+    _unsupportedPropChanges: Gate.prototype._unsupportedPropChanges.concat(['signed'])
 });
 
 // Unary arithmetic operations
@@ -44,7 +44,7 @@ export const Arith11 = Arith.define('Arith11', {
     bits: { in: 1, out: 1 },
     signed: false
 }, {
-    initialize: function() {
+    initialize() {
         const bits = this.get('bits');
         this.get('ports').items = [
             { id: 'in', group: 'in', dir: 'in', bits: bits.in },
@@ -54,10 +54,10 @@ export const Arith11 = Arith.define('Arith11', {
         Arith.prototype.initialize.apply(this, arguments);
         
         this.on('change:bits', (_,bits) => {
-            this.setPortsBits(bits);
+            this._setPortsBits(bits);
         });
     },
-    operation: function(data) {
+    operation(data) {
         const bits = this.get('bits');
         if (!data.in.isFullyDefined)
             return { out: Vector3vl.xes(bits.out) };
@@ -73,7 +73,7 @@ export const Arith21 = Arith.define('Arith21', {
     bits: { in1: 1, in2: 1, out: 1 },
     signed: { in1: false, in2: false }
 }, {
-    initialize: function() {
+    initialize() {
         const bits = this.get('bits');
         this.get('ports').items = [
             { id: 'in1', group: 'in', dir: 'in', bits: bits.in1 },
@@ -84,10 +84,10 @@ export const Arith21 = Arith.define('Arith21', {
         Arith.prototype.initialize.apply(this, arguments);
         
         this.on('change:bits', (_, bits) => {
-            this.setPortsBits(bits);
+            this._setPortsBits(bits);
         });
     },
-    operation: function(data) {
+    operation(data) {
         const bits = this.get('bits');
         const sgn = this.get('signed');
         if (!data.in1.isFullyDefined || !data.in2.isFullyDefined)
@@ -107,7 +107,7 @@ export const Shift = Arith.define('Shift', {
     signed: { in1: false, in2: false, out: false },
     fillx: false
 }, {
-    initialize: function() {
+    initialize() {
         const bits = this.get('bits');
         this.get('ports').items = [
             { id: 'in1', group: 'in', dir: 'in', bits: bits.in1 },
@@ -118,10 +118,10 @@ export const Shift = Arith.define('Shift', {
         Arith.prototype.initialize.apply(this, arguments);
         
         this.on('change:bits', (_, bits) => {
-            this.setPortsBits(bits);
+            this._setPortsBits(bits);
         });
     },
-    operation: function(data) {
+    operation(data) {
         const bits = this.get('bits');
         const sgn = this.get('signed');
         const fillx = this.get('fillx');
@@ -137,8 +137,8 @@ export const Shift = Arith.define('Shift', {
             : my_in.slice(am).concat(Vector3vl.make(am, fillx ? 0 : sgn.out ? my_in.get(my_in.bits-1) : -1));
         return { out: out.slice(0, bits.out) };
     },
-    gateParams: Arith.prototype.gateParams.concat(['fillx']),
-    unsupportedPropChanges: Arith.prototype.unsupportedPropChanges.concat(['fillx'])
+    _gateParams: Arith.prototype._gateParams.concat(['fillx']),
+    _unsupportedPropChanges: Arith.prototype._unsupportedPropChanges.concat(['fillx'])
 });
 
 // Comparison operations
@@ -147,7 +147,7 @@ export const Compare = Arith.define('Compare', {
     bits: { in1: 1, in2: 1 },
     signed: { in1: false, in2: false }
 }, {
-    initialize: function() {
+    initialize() {
         const bits = this.get('bits');
         this.get('ports').items = [
             { id: 'in1', group: 'in', dir: 'in', bits: bits.in1 },
@@ -158,10 +158,10 @@ export const Compare = Arith.define('Compare', {
         Arith.prototype.initialize.apply(this, arguments);
         
         this.on('change:bits', (_, bits) => {
-            this.setPortsBits(bits);
+            this._setPortsBits(bits);
         });
     },
-    operation: function(data) {
+    operation(data) {
         const bits = this.get('bits');
         const sgn = this.get('signed');
         if (!data.in1.isFullyDefined || !data.in2.isFullyDefined)
@@ -176,7 +176,7 @@ export const Compare = Arith.define('Compare', {
 
 // Equality operations
 export const EqCompare = Compare.define('EqCompare', {}, {
-    operation: function(data) {
+    operation(data) {
         const bits = this.get('bits');
         const sgn = this.get('signed');
         const in1 = bits.in1 >= bits.in2 ? data.in1 : 

--- a/src/cells/bus.mjs
+++ b/src/cells/bus.mjs
@@ -19,7 +19,7 @@ export const BitExtend = Box.define('BitExtend', {
         }
     }
 }, {
-    initialize: function() {
+    initialize() {
         const extend = this.get('extend');
         console.assert(extend.input <= extend.output);
         this.get('ports').items = [
@@ -30,12 +30,12 @@ export const BitExtend = Box.define('BitExtend', {
         Box.prototype.initialize.apply(this, arguments);
         
         this.on('change:extend', (_, extend) => {
-            this.setPortsBits({ in: extend.input, out: extend.output });
+            this._setPortsBits({ in: extend.input, out: extend.output });
         });
     },
-    operation: function(data) {
+    operation(data) {
         const ex = this.get('extend');
-        return { out: data.in.concat(Vector3vl.make(ex.output - ex.input, this.extbit(data.in))) };
+        return { out: data.in.concat(Vector3vl.make(ex.output - ex.input, this._extBit(data.in))) };
     },
     markup: Box.prototype.markup.concat([{
             tagName: 'text',
@@ -43,11 +43,11 @@ export const BitExtend = Box.define('BitExtend', {
             selector: 'value'
         }
     ]),
-    gateParams: Box.prototype.gateParams.concat(['extend'])
+    _gateParams: Box.prototype._gateParams.concat(['extend'])
 });
 export const BitExtendView = BoxView.extend({
-    autoResizeBox: true,
-    calculateBoxWidth: function() {
+    _autoResizeBox: true,
+    _calculateBoxWidth() {
         const text = this.el.querySelector('text.value');
         return text.getBBox().width + 10;
     }
@@ -58,7 +58,7 @@ export const ZeroExtend = BitExtend.define('ZeroExtend', {
         value: { text: 'zero-extend' }
     }
 }, {
-    extbit: function(i) {
+    _extBit(i) {
         return -1;
     }
 });
@@ -69,7 +69,7 @@ export const SignExtend = BitExtend.define('SignExtend', {
         value: { text: 'sign-extend' }
     }
 }, {
-    extbit: function(i) {
+    _extBit(i) {
         return i.get(i.bits - 1);
     }
 });
@@ -83,7 +83,7 @@ export const BusSlice = Box.define('BusSlice', {
     
     size: { width: 40, height: 24 }
 }, {
-    initialize: function() {
+    initialize() {
         const slice = this.get('slice');
         
         const val = slice.count == 1 ? slice.first : 
@@ -97,17 +97,17 @@ export const BusSlice = Box.define('BusSlice', {
         Box.prototype.initialize.apply(this, arguments);
         
         this.on('change:slice', (_, slice) => {
-            this.setPortsBits({ in: slice.total, out: slice.count });
+            this._setPortsBits({ in: slice.total, out: slice.count });
         });
     },
-    operation: function(data) {
+    operation(data) {
         const s = this.get('slice');
         return { out: data.in.slice(s.first, s.first + s.count) };
     },
-    gateParams: Box.prototype.gateParams.concat(['slice'])
+    _gateParams: Box.prototype._gateParams.concat(['slice'])
 });
 export const BusSliceView = BoxView.extend({
-    autoResizeBox: true
+    _autoResizeBox: true
 });
 
 // Bus grouping
@@ -118,7 +118,7 @@ export const BusRegroup = Box.define('BusRegroup', {
 
     size: { width: 40, height: undefined }
 }, {
-    initialize: function() {
+    initialize() {
         var bits = 0;
         const ports = [];
         const groups = this.get('groups');
@@ -138,17 +138,17 @@ export const BusRegroup = Box.define('BusRegroup', {
         
         Box.prototype.initialize.apply(this, arguments);
     },
-    gateParams: Box.prototype.gateParams.concat(['groups']),
-    unsupportedPropChanges: Box.prototype.unsupportedPropChanges.concat(['groups'])
+    _gateParams: Box.prototype._gateParams.concat(['groups']),
+    _unsupportedPropChanges: Box.prototype._unsupportedPropChanges.concat(['groups'])
 });
 export const BusRegroupView = BoxView.extend({
-    autoResizeBox: true
+    _autoResizeBox: true
 });
 
 export const BusGroup = BusRegroup.define('BusGroup', {
 }, {
     group_dir : 'in',
-    operation: function(data) {
+    operation(data) {
         const outdata = [];
         for (const num of this.get('groups').keys()) {
             outdata.push(data['in' + num]);
@@ -161,7 +161,7 @@ export const BusGroupView = BusRegroupView;
 export const BusUngroup = BusRegroup.define('BusUngroup', {
 }, {
     group_dir : 'out',
-    operation: function(data) {
+    operation(data) {
         const outdata = {};
         let pos = 0;
         for (const [num, gbits] of this.get('groups').entries()) {

--- a/src/cells/dff.mjs
+++ b/src/cells/dff.mjs
@@ -17,15 +17,15 @@ export const Dff = Box.define('Dff', {
     ports: {
         groups: {
             'in': {
-                position: Box.prototype.getStackedPosition({ side: 'left' })
+                position: Box.prototype._getStackedPosition({ side: 'left' })
             },
             'out': {
-                position: Box.prototype.getStackedPosition({ side: 'right' })
+                position: Box.prototype._getStackedPosition({ side: 'right' })
             }
         }
     }
 }, {
-    initialize: function() {
+    initialize() {
         const bits = this.get('bits');
         const initial = this.get('initial');
         const polarity = this.get('polarity');
@@ -61,7 +61,7 @@ export const Dff = Box.define('Dff', {
         
         Box.prototype.initialize.apply(this, arguments);
     },
-    operation: function(data) {
+    operation(data) {
         const polarity = this.get('polarity');
         const pol = what => polarity[what] ? 1 : -1
         let last_clk;
@@ -80,10 +80,10 @@ export const Dff = Box.define('Dff', {
                 return this.get('outputSignals');
         } else return { out: data.in };
     },
-    gateParams: Box.prototype.gateParams.concat(['polarity', 'bits', 'initial']),
-    unsupportedPropChanges: Box.prototype.unsupportedPropChanges.concat(['polarity', 'bits', 'initial'])
+    _gateParams: Box.prototype._gateParams.concat(['polarity', 'bits', 'initial']),
+    _unsupportedPropChanges: Box.prototype._unsupportedPropChanges.concat(['polarity', 'bits', 'initial'])
 });
 export const DffView = BoxView.extend({
-    autoResizeBox: true
+    _autoResizeBox: true
 });
 

--- a/src/cells/fsm.mjs
+++ b/src/cells/fsm.mjs
@@ -22,15 +22,15 @@ export const FSM = Box.define('FSM', {
     ports: {
         groups: {
             'in': {
-                position: Box.prototype.getStackedPosition({ side: 'left' })
+                position: Box.prototype._getStackedPosition({ side: 'left' })
             },
             'out': {
-                position: Box.prototype.getStackedPosition({ side: 'right' })
+                position: Box.prototype._getStackedPosition({ side: 'right' })
             }
         }
     }
 }, {
-    initialize: function() {
+    initialize() {
         const bits = this.get('bits');
         const polarity = this.get('polarity');
         
@@ -104,7 +104,7 @@ export const FSM = Box.define('FSM', {
             }
         });
     },
-    operation: function(data) {
+    operation(data) {
         const bits = this.get('bits');
         const polarity = this.get('polarity');
         const next_trans = () => {
@@ -139,18 +139,18 @@ export const FSM = Box.define('FSM', {
         }
     },
     markup: Box.prototype.markup.concat(Box.prototype.markupZoom),
-    gateParams: Box.prototype.gateParams.concat(['bits', 'polarity', 'states', 'init_state', 'trans_table']),
-    unsupportedPropChanges: Box.prototype.unsupportedPropChanges.concat(['bits', 'polarity', 'states', 'init_state', 'trans_table'])
+    _gateParams: Box.prototype._gateParams.concat(['bits', 'polarity', 'states', 'init_state', 'trans_table']),
+    _unsupportedPropChanges: Box.prototype._unsupportedPropChanges.concat(['bits', 'polarity', 'states', 'init_state', 'trans_table'])
 });
 
 export const FSMView = BoxView.extend({
-    autoResizeBox: true,
+    _autoResizeBox: true,
     events: {
         "click foreignObject.tooltip": "stopprop",
         "mousedown foreignObject.tooltip": "stopprop",
-        "click a.zoom": "displayEditor"
+        "click a.zoom": "_displayEditor"
     },
-    displayEditor(evt) {
+    _displayEditor(evt) {
         evt.stopPropagation();
         const div = $('<div>', {
             title: "FSM: " + this.model.get('label')

--- a/src/cells/gates.mjs
+++ b/src/cells/gates.mjs
@@ -50,12 +50,12 @@ export const GateSVG = Gate.define('GateSVG', {
             selector: 'body'
         }
     ]),
-    gateParams: Gate.prototype.gateParams.concat(['bits'])
+    _gateParams: Gate.prototype._gateParams.concat(['bits'])
 });
 
 // Single-input gate model
 export const Gate11 = GateSVG.define('Gate11', {}, {
-    initialize: function() {
+    initialize() {
         const bits = this.get('bits');
         this.get('ports').items = [
             { id: 'in', group: 'in', dir: 'in', bits: bits },
@@ -65,14 +65,14 @@ export const Gate11 = GateSVG.define('Gate11', {}, {
         GateSVG.prototype.initialize.apply(this, arguments);
         
         this.on('change:bits', (_, bits) => {
-            this.setPortsBits({ in: bits, out: bits });
+            this._setPortsBits({ in: bits, out: bits });
         });
     }
 });
 
 // Two-input gate model
 export const Gate21 = GateSVG.define('Gate21', {}, {
-    initialize: function() {
+    initialize() {
         const bits = this.get('bits');
         this.get('ports').items = [
             { id: 'in1', group: 'in', dir: 'in', bits: bits },
@@ -83,14 +83,14 @@ export const Gate21 = GateSVG.define('Gate21', {}, {
         GateSVG.prototype.initialize.apply(this, arguments);
         
         this.on('change:bits', (_, bits) => {
-            this.setPortsBits({ in1: bits, in2: bits, out: bits });
+            this._setPortsBits({ in1: bits, in2: bits, out: bits });
         });
     }
 });
 
 // Reducing gate model
 export const GateReduce = GateSVG.define('GateReduce', {}, {
-    initialize: function() {
+    initialize() {
         const bits = this.get('bits');
         this.get('ports').items = [
             { id: 'in', group: 'in', dir: 'in', bits: bits },
@@ -100,7 +100,7 @@ export const GateReduce = GateSVG.define('GateReduce', {}, {
         GateSVG.prototype.initialize.apply(this, arguments);
         
         this.on('change:bits', (_, bits) => {
-            this.setPortsBits({ in: bits });
+            this._setPortsBits({ in: bits });
         });
     }
 });
@@ -109,7 +109,7 @@ export const GateReduce = GateSVG.define('GateReduce', {}, {
 export const Repeater = Gate11.define('Repeater', {
     attrs: { body: { d: buf_path }}
 }, {
-    operation: function(data) {
+    operation(data) {
         return { out: data.in };
     }
 });
@@ -119,7 +119,7 @@ export const RepeaterView = GateView;
 export const Not = Gate11.define('Not', {
     attrs: { body: { d: buf_path }}
 }, {
-    operation: function(data) {
+    operation(data) {
         return { out: data.in.not() };
     },
     markup: Gate11.prototype.markup.concat([neg_markup])
@@ -130,7 +130,7 @@ export const NotView = GateView;
 export const Or = Gate21.define('Or', {
     attrs: { body: { d: or_path }}
 }, {
-    operation: function(data) {
+    operation(data) {
         return { out: data.in1.or(data.in2) };
     }
 });
@@ -140,7 +140,7 @@ export const OrView = GateView;
 export const And = Gate21.define('And', {
     attrs: { body: { d: and_path }}
 }, {
-    operation: function(data) {
+    operation(data) {
         return { out: data.in1.and(data.in2) };
     }
 });
@@ -150,7 +150,7 @@ export const AndView = GateView;
 export const Nor = Gate21.define('Nor', {
     attrs: { body: { d: or_path }}
 }, {
-    operation: function(data) {
+    operation(data) {
         return { out: data.in1.nor(data.in2) };
     },
     markup: Gate21.prototype.markup.concat([neg_markup])
@@ -161,7 +161,7 @@ export const NorView = GateView;
 export const Nand = Gate21.define('Nand', {
     attrs: { body: { d: and_path }}
 }, {
-    operation: function(data) {
+    operation(data) {
         return { out: data.in1.nand(data.in2) };
     },
     markup: Gate21.prototype.markup.concat([neg_markup])
@@ -172,7 +172,7 @@ export const NandView = GateView;
 export const Xor = Gate21.define('Xor', {
     attrs: { body: { d: or_path }}
 }, {
-    operation: function(data) {
+    operation(data) {
         return { out: data.in1.xor(data.in2) };
     },
     markup: Gate21.prototype.markup.concat([xor_arc_path_markup])
@@ -183,7 +183,7 @@ export const XorView = GateView;
 export const Xnor = Gate21.define('Xnor', {
     attrs: { body: { d: or_path }}
 }, {
-    operation: function(data) {
+    operation(data) {
         return { out: data.in1.xnor(data.in2) };
     },
     markup: Gate21.prototype.markup.concat([xor_arc_path_markup, neg_markup])
@@ -194,7 +194,7 @@ export const XnorView = GateView;
 export const OrReduce = GateReduce.define('OrReduce', {
     attrs: { body: { d: or_path }}
 }, {
-    operation: function(data) {
+    operation(data) {
         return { out: data.in.reduceOr() };
     }
 });
@@ -204,7 +204,7 @@ export const OrReduceView = GateView;
 export const NorReduce = GateReduce.define('NorReduce', {
     attrs: { body: { d: or_path }}
 }, {
-    operation: function(data) {
+    operation(data) {
         return { out: data.in.reduceNor() };
     },
     markup: GateReduce.prototype.markup.concat([neg_markup])
@@ -215,7 +215,7 @@ export const NorReduceView = GateView;
 export const AndReduce = GateReduce.define('AndReduce', {
     attrs: { body: { d: and_path }}
 }, {
-    operation: function(data) {
+    operation(data) {
         return { out: data.in.reduceAnd() };
     }
 });
@@ -225,7 +225,7 @@ export const AndReduceView = GateView;
 export const NandReduce = GateReduce.define('NandReduce', {
     attrs: { body: { d: and_path }}
 }, {
-    operation: function(data) {
+    operation(data) {
         return { out: data.in.reduceNand() };
     },
     markup: GateReduce.prototype.markup.concat([neg_markup])
@@ -236,7 +236,7 @@ export const NandReduceView = GateView;
 export const XorReduce = GateReduce.define('XorReduce', {
     attrs: { body: { d: or_path }}
 }, {
-    operation: function(data) {
+    operation(data) {
         return { out: data.in.reduceXor() };
     },
     markup: GateReduce.prototype.markup.concat([xor_arc_path_markup])
@@ -247,7 +247,7 @@ export const XorReduceView = GateView;
 export const XnorReduce = GateReduce.define('XnorReduce', {
     attrs: { body: { d: or_path }}
 }, {
-    operation: function(data) {
+    operation(data) {
         return { out: data.in.reduceXnor() };
     },
     markup: GateReduce.prototype.markup.concat([xor_arc_path_markup, neg_markup])

--- a/src/cells/io.mjs
+++ b/src/cells/io.mjs
@@ -13,7 +13,7 @@ export const NumBase = Box.define('NumBase', {
     numbase: 'hex',
     bits: 1
 }, {
-    initialize: function(args) {
+    initialize() {
         Box.prototype.initialize.apply(this, arguments);
 
         this.on('change:bits', (_, bits) => {
@@ -38,23 +38,23 @@ export const NumBase = Box.define('NumBase', {
             }]
         }
     ]),
-    gateParams: Box.prototype.gateParams.concat(['numbase'])
+    _gateParams: Box.prototype._gateParams.concat(['numbase'])
 });
 export const NumBaseView = BoxView.extend({
     presentationAttributes: BoxView.addPresentationAttributes({
         bits: 'BITS',
         numbase: 'NUMBASE'
     }),
-    autoResizeBox: true,
+    _autoResizeBox: true,
     events: {
         "click select.numbase": "stopprop",
         "mousedown select.numbase": "stopprop",
-        "change select.numbase": "changeNumbase"
+        "change select.numbase": "_changeNumbase"
     },
-    changeNumbase: function(evt) {
+    _changeNumbase(evt) {
         this.model.set('numbase', evt.target.value || 'bin');
     },
-    calculateBoxWidth: function() {
+    _calculateBoxWidth() {
         const testtext = document.createElementNS('http://www.w3.org/2000/svg', 'text');
         $(testtext).text(Array(this.model.get('bits')).fill('0').join(''))
             .attr('class', 'numvalue')
@@ -66,11 +66,11 @@ export const NumBaseView = BoxView.extend({
     confirmUpdate(flags) {
         BoxView.prototype.confirmUpdate.apply(this, arguments);
         if (this.hasFlag(flags, 'BITS') || this.hasFlag(flags, 'RENDER'))
-            this.makeNumBaseSelector();
+            this._makeNumBaseSelector();
         if (this.hasFlag(flags, 'NUMBASE'))
-            this.updateNumBaseSelector();
+            this._updateNumBaseSelector();
     },
-    makeNumBaseSelector() {
+    _makeNumBaseSelector() {
         this.$('select.numbase').empty();
         const numbase = this.model.get('numbase');
         const display3vl = this.model.graph._display3vl;
@@ -82,7 +82,7 @@ export const NumBaseView = BoxView.extend({
                 .appendTo(this.$('select.numbase'));
         }
     },
-    updateNumBaseSelector() {
+    _updateNumBaseSelector() {
         this.$('select.numbase').val(this.model.get('numbase'));
     }
 });
@@ -101,7 +101,7 @@ export const NumDisplay = NumBase.define('NumDisplay', {
         },
     }
 }, {
-    initialize: function(args) {
+    initialize() {
         const bits = this.get('bits');
         this.get('ports').items = [
             { id: 'in', group: 'in', dir: 'in', bits: bits }
@@ -110,7 +110,7 @@ export const NumDisplay = NumBase.define('NumDisplay', {
         NumBase.prototype.initialize.apply(this, arguments);
         
         this.on('change:bits', (_, bits) => {
-            this.setPortsBits({ in: bits });
+            this._setPortsBits({ in: bits });
         });
     },
     markup: NumBase.prototype.markup.concat([{
@@ -119,25 +119,25 @@ export const NumDisplay = NumBase.define('NumDisplay', {
             selector: 'value'
         }
     ]),
-    getLogicValue: function() {
+    getLogicValue() {
         return this.get('inputSignals').in;
     },
-    gateParams: NumBase.prototype.gateParams.concat(['bits']),
+    _gateParams: NumBase.prototype._gateParams.concat(['bits']),
     numbaseType: 'show'
 });
 export const NumDisplayView = NumBaseView.extend({
     confirmUpdate(flags) {
         NumBaseView.prototype.confirmUpdate.apply(this, arguments);
         if (this.hasFlag(flags, 'SIGNAL') ||
-            this.hasFlag(flags, 'NUMBASE')) this.settext();
+            this.hasFlag(flags, 'NUMBASE')) this._showText();
     },
-    settext() {
+    _showText() {
         const display3vl = this.model.graph._display3vl;
         this.$('text.value tspan').text(display3vl.show(this.model.get('numbase'), this.model.get('inputSignals').in));
     },
     update() {
         NumBaseView.prototype.update.apply(this, arguments);
-        this.settext();
+        this._showText();
     }
 });
 
@@ -156,7 +156,7 @@ export const NumEntry = NumBase.define('NumEntry', {
         }
     }
 }, {
-    initialize: function(args) {
+    initialize() {
         const bits = this.get('bits');
         this.get('ports').items = [
             { id: 'out', group: 'out', dir: 'out', bits: bits }
@@ -166,10 +166,10 @@ export const NumEntry = NumBase.define('NumEntry', {
         NumBase.prototype.initialize.apply(this, arguments);
         
         this.on('change:bits', (_, bits) => {
-            this.setPortsBits({ out: bits });
+            this._setPortsBits({ out: bits });
         });
     },
-    operation: function() {
+    operation() {
         return { out: this.get('buttonState') };
     },
     markup: NumBase.prototype.markup.concat([{
@@ -185,12 +185,12 @@ export const NumEntry = NumBase.define('NumEntry', {
             }]
         }
     ]),
-    setLogicValue: function(sig) {
+    setLogicValue(sig) {
         if (sig.bits != this.get('bits')) 
             throw new Error("setLogicValue: wrong number of bits");
         this.set('buttonState', sig);
     },
-    gateParams: NumBase.prototype.gateParams.concat(['bits']),
+    _gateParams: NumBase.prototype._gateParams.concat(['bits']),
     numbaseType: 'read'
 });
 export const NumEntryView = NumBaseView.extend({
@@ -200,19 +200,19 @@ export const NumEntryView = NumBaseView.extend({
     events: _.merge({
         "click input": "stopprop",
         "mousedown input": "stopprop",
-        "change input": "change"
+        "change input": "_onChange"
     }, NumBaseView.prototype.events),
     confirmUpdate(flags) {
         NumBaseView.prototype.confirmUpdate.apply(this, arguments);
         if (this.hasFlag(flags, 'SIGNAL') ||
-            this.hasFlag(flags, 'NUMBASE')) this.settext();
+            this.hasFlag(flags, 'NUMBASE')) this._showText();
     },
-    settext() {
+    _showText() {
         const display3vl = this.model.graph._display3vl;
         this.$('input').val(display3vl.show(this.model.get('numbase'), this.model.get('buttonState')));
         this.$('input').removeClass('invalid');
     },
-    change(evt) {
+    _onChange(evt) {
         const numbase = this.model.get('numbase');
         const bits = this.model.get('bits');
         const display3vl = this.model.graph._display3vl;
@@ -225,7 +225,7 @@ export const NumEntryView = NumBaseView.extend({
     },
     update() {
         NumBaseView.prototype.update.apply(this, arguments);
-        this.settext();
+        this._showText();
     }
 });
 
@@ -254,10 +254,10 @@ export const Lamp = Box.define('Lamp', {
             selector: 'led'
         }
     ]),
-    getLogicValue: function() {
+    getLogicValue() {
         return this.get('inputSignals').in;
     },
-    unsupportedPropChanges: Box.prototype.unsupportedPropChanges.concat(['bits'])
+    _unsupportedPropChanges: Box.prototype._unsupportedPropChanges.concat(['bits'])
 });
 export const LampView = BoxView.extend({
     attrs: _.merge({}, BoxView.prototype.attrs, {
@@ -270,20 +270,20 @@ export const LampView = BoxView.extend({
     confirmUpdate(flags) {
         BoxView.prototype.confirmUpdate.apply(this, arguments);
         if (this.hasFlag(flags, 'SIGNAL')) {
-            this.updateLamp();
+            this._updateLamp();
         };
     },
-    updateLamp() {
+    _updateLamp() {
         const signal = this.model.get('inputSignals').in;
         const attrs = this.attrs.lamp[
             signal.isHigh ? 'high' :
             signal.isLow ? 'low' : 'undef'
         ];
-        this.applyAttrs(attrs);
+        this._applyAttrs(attrs);
     },
     update() {
         BoxView.prototype.update.apply(this, arguments);
-        this.updateLamp();
+        this._updateLamp();
     }
 });
 
@@ -310,7 +310,7 @@ export const Button = Box.define('Button', {
         }
     }
 }, {
-    operation: function() {
+    operation() {
         return { out: this.get('buttonState') ? Vector3vl.ones(1) : Vector3vl.zeros(1) };
     },
     markup: Box.prototype.markup.concat([{
@@ -319,12 +319,12 @@ export const Button = Box.define('Button', {
             selector: 'btnface'
         }
     ]),
-    setLogicValue: function(sig) {
+    setLogicValue(sig) {
         if (sig.bits != 1) 
             throw new Error("setLogicValue: wrong number of bits");
         this.set('buttonState', sig.isHigh);
     },
-    unsupportedPropChanges: Box.prototype.unsupportedPropChanges.concat(['bits'])
+    _unsupportedPropChanges: Box.prototype._unsupportedPropChanges.concat(['bits'])
 });
 export const ButtonView = BoxView.extend({
     attrs: _.merge({}, BoxView.prototype.attrs, {
@@ -339,25 +339,25 @@ export const ButtonView = BoxView.extend({
     confirmUpdate(flags) {
         BoxView.prototype.confirmUpdate.apply(this, arguments);
         if (this.hasFlag(flags, 'SIGNAL')) {
-            this.updateButton();
+            this._updateButton();
         }
     },
-    updateButton() {
+    _updateButton() {
         const buttonState = this.model.get('buttonState');
         const attrs = this.attrs.button[
             buttonState ? 'high' : 'low'
         ];
-        this.applyAttrs(attrs);
+        this._applyAttrs(attrs);
     },
     update() {
         BoxView.prototype.update.apply(this, arguments);
-        this.updateButton();
+        this._updateButton();
     },
     events: {
-        "click .btnface": "activateButton",
+        "click .btnface": "_activateButton",
         "mousedown .btnface": "stopprop"
     },
-    activateButton() {
+    _activateButton() {
         this.model.set('buttonState', !this.model.get('buttonState'));
     }
 });
@@ -378,7 +378,7 @@ export const IO = Box.define('IO', {
         }
     }
 }, {
-    initialize: function(args) {
+    initialize() {
         const bits = this.get('bits');
         this.get('ports').items = [
             { id: this.io_dir, group: this.io_dir, dir: this.io_dir, bits: bits }
@@ -389,18 +389,18 @@ export const IO = Box.define('IO', {
         this.on('change:bits', (_, bits) => {
             const b = {};
             b[this.io_dir] = bits;
-            this.setPortsBits(b);
+            this._setPortsBits(b);
         });
         this.bindAttrToProp('text.ioname/text', 'net');
     },
-    setPortsBits: function(portsBits) {
-        Box.prototype.setPortsBits.apply(this, arguments);
+    _setPortsBits(portsBits) {
+        Box.prototype._setPortsBits.apply(this, arguments);
         
         const subcir = this.graph.get('subcircuit');
         if (subcir == null) return; // not inside a subcircuit
         const portsBitsSubcir = {};
         portsBitsSubcir[this.get('net')] = portsBits[this.io_dir];
-        subcir.setPortsBits(portsBitsSubcir);
+        subcir._setPortsBits(portsBitsSubcir);
     },
     markup: Box.prototype.markup.concat([{
             tagName: 'text',
@@ -408,11 +408,11 @@ export const IO = Box.define('IO', {
             selector: 'ioname'
         }
     ]),
-    gateParams: Box.prototype.gateParams.concat(['bits','net'])
+    _gateParams: Box.prototype._gateParams.concat(['bits','net'])
 });
 export const IOView = BoxView.extend({
-    autoResizeBox: true,
-    calculateBoxWidth: function() {
+    _autoResizeBox: true,
+    _calculateBoxWidth() {
         const text = this.el.querySelector('text.ioname');
         if (text.getAttribute('display') !== 'none') return text.getBBox().width + 10;
         return 20;
@@ -422,7 +422,7 @@ export const IOView = BoxView.extend({
 // Input model
 export const Input = IO.define('Input', {}, {
     io_dir: 'out',
-    setLogicValue: function(sig) {
+    setLogicValue(sig) {
         if (sig.bits != this.get('bits'))
             throw new Error("setLogicValue: wrong number of bits");
         this.set('outputSignals', { out: sig });
@@ -433,12 +433,12 @@ export const InputView = IOView;
 // Output model
 export const Output = IO.define('Output', {}, {
     io_dir: 'in',
-    changeInputSignals: function(sigs) {
+    _changeInputSignals(sigs) {
         const subcir = this.graph.get('subcircuit');
         if (subcir == null) return; // not inside a subcircuit
-        subcir.setOutput(sigs.in, this.get('net'));
+        subcir._setOutput(sigs.in, this.get('net'));
     },
-    getLogicValue: function() {
+    getLogicValue() {
         return this.get('inputSignals').in;
     }
 });
@@ -458,7 +458,7 @@ export const Constant = NumBase.define('Constant', {
         }
     }
 }, {
-    initialize: function(args) {
+    initialize() {
         const constant = this.get('constant');
         const bits = constant.length;
         this.set('bits', bits);
@@ -471,12 +471,12 @@ export const Constant = NumBase.define('Constant', {
        
         this.on('change:constant', (_, constant) => {
             const bits = constant.length;
-            this.setPortsBits({ out: bits });
+            this._setPortsBits({ out: bits });
             this.set('bits', bits);
             this.set('constantCache', Vector3vl.fromBin(constant, bits));
         });
     },
-    operation: function() {
+    operation() {
         return { out: this.get('constantCache') };
     },
     markup: NumBase.prototype.markup.concat([{
@@ -485,7 +485,7 @@ export const Constant = NumBase.define('Constant', {
             selector: 'value'
         }
     ]),
-    gateParams: NumBase.prototype.gateParams.concat(['constant']),
+    _gateParams: NumBase.prototype._gateParams.concat(['constant']),
     numbaseType: 'show'
 });
 export const ConstantView = NumBaseView.extend({
@@ -495,15 +495,15 @@ export const ConstantView = NumBaseView.extend({
     confirmUpdate(flags) {
         NumBaseView.prototype.confirmUpdate.apply(this, arguments);
         if (this.hasFlag(flags, 'CONSTANT') ||
-            this.hasFlag(flags, 'NUMBASE')) this.settext();
+            this.hasFlag(flags, 'NUMBASE')) this._showText();
     },
-    settext() {
+    _showText() {
         const display3vl = this.model.graph._display3vl;
         this.$('text.value tspan').text(display3vl.show(this.model.get('numbase'), this.model.get('constantCache')));
     },
     update() {
         NumBaseView.prototype.update.apply(this, arguments);
-        this.settext();
+        this._showText();
     }
 });
 
@@ -520,11 +520,11 @@ export const Clock = Box.define('Clock', {
 
     size: { width: 30, height: 30 }
 }, {
-    initialize: function(args) {
+    initialize() {
         Box.prototype.initialize.apply(this, arguments);
         this.set('outputSignals', { out: Vector3vl.zeros(1) });
     },
-    operation: function() {
+    operation() {
         // trigger next clock edge
         this.trigger("change:inputSignals", this, {});
         return { out: this.get('outputSignals').out.not() };
@@ -548,7 +548,7 @@ export const Clock = Box.define('Clock', {
             }]
         }
     ]),
-    unsupportedPropChanges: Box.prototype.unsupportedPropChanges.concat(['bits'])
+    _unsupportedPropChanges: Box.prototype._unsupportedPropChanges.concat(['bits'])
 });
 export const ClockView = BoxView.extend({
     presentationAttributes: BoxView.addPresentationAttributes({
@@ -557,8 +557,8 @@ export const ClockView = BoxView.extend({
     events: {
         "click input": "stopprop",
         "mousedown input": "stopprop",
-        "change input": "changePropagation",
-        "input input": "changePropagation"
+        "change input": "_changePropagation",
+        "input input": "_changePropagation"
     },
     render(args) {
         BoxView.prototype.render.apply(this, arguments);
@@ -568,7 +568,7 @@ export const ClockView = BoxView.extend({
         BoxView.prototype.confirmUpdate.apply(this, arguments);
         if (this.hasFlag(flags, 'SIGNAL')) this.updatePropagation();
     },
-    changePropagation(evt) {
+    _changePropagation(evt) {
         const val = evt.target.value;
         const valid = String(val) == String(Number(val));
         if (valid) this.model.set('propagation', Number(val) || 1);

--- a/src/cells/memory.mjs
+++ b/src/cells/memory.mjs
@@ -26,15 +26,15 @@ export const Memory = Box.define('Memory', {
     ports: {
         groups: {
             'in': {
-                position: Box.prototype.getStackedPosition({ side: 'left' })
+                position: Box.prototype._getStackedPosition({ side: 'left' })
             },
             'out': {
-                position: Box.prototype.getStackedPosition({ side: 'right' })
+                position: Box.prototype._getStackedPosition({ side: 'right' })
             }
         }
     }
 }, {
-    initialize: function() {
+    initialize() {
         const bits = this.get('bits');
         const abits = this.get('abits');
         const rdports = this.get('rdports');
@@ -115,7 +115,7 @@ export const Memory = Box.define('Memory', {
             this.attr('path.portsplit/d', 'M ' + path.join(' M '));
         });
     },
-    operation: function(data) {
+    operation(data) {
         const out = {};
         const check_enabled = (portname, port) => {
             const pol = what => port[what + '_polarity'] ? 1 : -1;
@@ -171,7 +171,7 @@ export const Memory = Box.define('Memory', {
             if (port.transparent) do_read('rd' + num, port);
         return out;
     },
-    updateOutputs: function(addr) {
+    _updateOutputs(addr) {
         if (addr < 0 || addr >= this.get('words')) return;
         const data = this.get('inputSignals');
         const calc_addr = sig => help.sig2bigint(sig, false) - this.get('offset');
@@ -196,23 +196,23 @@ export const Memory = Box.define('Memory', {
             className: 'portsplit',
             selector: 'portsplit'
         }], Box.prototype.markupZoom),
-    getGateParams: function() { 
+    getGateParams() {
         // hack to get memdata back
         const params = Box.prototype.getGateParams.apply(this, arguments);
         params.memdata = this.memdata.toJSON();
         return params;
     },
-    gateParams: Box.prototype.gateParams.concat(['bits', 'abits', 'rdports', 'wrports', 'words', 'offset']),
-    unsupportedPropChanges: Box.prototype.unsupportedPropChanges.concat(['bits', 'abits', 'rdports', 'wrports', 'words', 'offset'])
+    _gateParams: Box.prototype._gateParams.concat(['bits', 'abits', 'rdports', 'wrports', 'words', 'offset']),
+    _unsupportedPropChanges: Box.prototype._unsupportedPropChanges.concat(['bits', 'abits', 'rdports', 'wrports', 'words', 'offset'])
 });
 export const MemoryView = BoxView.extend({
-    autoResizeBox: true,
+    _autoResizeBox: true,
     events: {
         "click foreignObject.tooltip": "stopprop",
         "mousedown foreignObject.tooltip": "stopprop",
-        "click a.zoom": "displayEditor"
+        "click a.zoom": "_displayEditor"
     },
-    displayEditor(evt) {
+    _displayEditor(evt) {
         evt.stopPropagation();
         const display3vl = this.model.graph._display3vl;
         const div = $('<div>', {
@@ -305,7 +305,7 @@ export const MemoryView = BoxView.extend({
             if (display3vl.validate(numbase, evt.target.value, bits)) {
                 const val = display3vl.read(numbase, evt.target.value, bits);
                 memdata.set(addr, val);
-                this.model.updateOutputs(addr);
+                this.model._updateOutputs(addr);
                 target.removeClass('invalid');
             } else {
                 target.addClass('invalid');

--- a/src/cells/mux.mjs
+++ b/src/cells/mux.mjs
@@ -27,7 +27,7 @@ export const GenMux = Gate.define('GenMux', {
         }
     }
 }, {
-    initialize: function() {
+    initialize() {
         const bits = this.get('bits');
         const ports = [
             { id: 'sel', group: 'in2', dir: 'in', bits: bits.sel },
@@ -59,18 +59,18 @@ export const GenMux = Gate.define('GenMux', {
         
         this.on('change:size', (_, size) => drawBorder(size));
     },
-    operation: function(data) {
+    operation(data) {
         const i = this.muxInput(data.sel);
         if (i === undefined) return { out: Vector3vl.xes(this.get('bits').in) };
         return { out: data['in' + i] };
     },
     //add offset of 20pt to account for the top selection port at layout time
-    getLayoutSize: function() {
+    getLayoutSize() {
         const size = this.size();
         size.height += 20;
         return size;
     },
-    setLayoutPosition: function(position) {
+    setLayoutPosition(position) {
         this.set('position', {
             x: position.x - position.width / 2,
             y: position.y - position.height / 2 + 20
@@ -82,8 +82,8 @@ export const GenMux = Gate.define('GenMux', {
             selector: 'body'
         }
     ]),
-    gateParams: Gate.prototype.gateParams.concat(['bits']),
-    unsupportedPropChanges: Gate.prototype.unsupportedPropChanges.concat(['bits'])
+    _gateParams: Gate.prototype._gateParams.concat(['bits']),
+    _unsupportedPropChanges: Gate.prototype._unsupportedPropChanges.concat(['bits'])
 });
 export const GenMuxView = GateView.extend({
     initialize() {
@@ -93,14 +93,14 @@ export const GenMuxView = GateView.extend({
     confirmUpdate(flags) {
         GateView.prototype.confirmUpdate.apply(this, arguments);
         if (this.hasFlag(flags, 'SIGNAL')) {
-            this.updateMux(this.model.get('inputSignals'));
+            this._updateMux(this.model.get('inputSignals'));
         }
     },
     render() {
         GateView.prototype.render.apply(this, arguments);
-        this.updateMux(this.model.get('inputSignals'));
+        this._updateMux(this.model.get('inputSignals'));
     },
-    updateMux(data) {
+    _updateMux(data) {
         const i = this.model.muxInput(data.sel);
         for (const num of Array(this.n_ins).keys()) {
             this.$('[port=in' + num + '] path.decor').css('visibility', i == num ? 'visible' : 'hidden');

--- a/src/cells/subcircuit.mjs
+++ b/src/cells/subcircuit.mjs
@@ -24,7 +24,7 @@ export const Subcircuit = Box.define('Subcircuit', {
         }
     }
 }, {
-    initialize: function() {
+    initialize() {
         this.bindAttrToProp('text.type/text', 'celltype');
         
         const graph = this.get('graph');
@@ -64,25 +64,25 @@ export const Subcircuit = Box.define('Subcircuit', {
         
         Box.prototype.initialize.apply(this, arguments);
     },
-    setInput: function(sig, port) {
-        Box.prototype.setInput.apply(this, arguments);
+    _setInput(sig, port) {
+        Box.prototype._setInput.apply(this, arguments);
         const iomap = this.get('circuitIOmap');
         const input = this.get('graph').getCell(iomap[port]);
         console.assert(input.setLogicValue);
         input.setLogicValue(sig);
     },
-    setOutput: function(sig, port) {
+    _setOutput(sig, port) {
         const signals = _.clone(this.get('outputSignals'));
         signals[port] = sig;
         this.set('outputSignals', signals);
     },
     //add offset of 10pt to account for the top label at layout time
-    getLayoutSize: function() {
+    getLayoutSize() {
         const size = this.size();
         size.height += 10;
         return size;
     },
-    setLayoutPosition: function(position) {
+    setLayoutPosition(position) {
         this.set('position', {
             x: position.x - position.width / 2,
             y: position.y - position.height / 2 + 10
@@ -98,8 +98,8 @@ export const Subcircuit = Box.define('Subcircuit', {
             selector: 'type'
         }
     ], Box.prototype.markupZoom),
-    gateParams: Box.prototype.gateParams.concat(['celltype']),
-    unsupportedPropChanges: Box.prototype.unsupportedPropChanges.concat(['celltype'])
+    _gateParams: Box.prototype._gateParams.concat(['celltype']),
+    _unsupportedPropChanges: Box.prototype._unsupportedPropChanges.concat(['celltype'])
 });
 
 export const SubcircuitView = BoxView.extend({
@@ -109,33 +109,33 @@ export const SubcircuitView = BoxView.extend({
             none: { wrapper: { 'stroke-opacity': '0' } }
         }
     }),
-    autoResizeBox: true,
+    _autoResizeBox: true,
     presentationAttributes: BoxView.addPresentationAttributes({
         warning: 'WARNING'
     }),
     confirmUpdate(flags) {
         BoxView.prototype.confirmUpdate.apply(this, arguments);
         if (this.hasFlag(flags, 'WARNING')) {
-            this.updateWarning();
+            this._updateWarning();
         }
     },
-    updateWarning() {
+    _updateWarning() {
         const warning = this.model.get('warning');
         const attrs = this.attrs.warning[
             warning ? 'warn' : 'none'
         ];
-        this.applyAttrs(attrs);
+        this._applyAttrs(attrs);
     },
     update() {
         BoxView.prototype.update.apply(this, arguments);
-        this.updateWarning();
+        this._updateWarning();
     },
     events: {
         "click foreignObject.tooltip": "stopprop",
         "mousedown foreignObject.tooltip": "stopprop",
         "click a.zoom": "zoomInCircuit"
     },
-    zoomInCircuit: function(evt) {
+    zoomInCircuit(evt) {
         evt.stopPropagation();
         this.paper.trigger('open:subcircuit', this.model);
         return false;

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -35,7 +35,7 @@ export class Circuit extends HeadlessCircuit {
         if (this.hasWarnings())
             return; //todo: print/show error
         this._interval = setInterval(() => {
-            this.updateGates();
+            this._updateGates();
         }, this._interval_ms);
         this.trigger('changeRunning');
     }
@@ -44,7 +44,7 @@ export class Circuit extends HeadlessCircuit {
             return; //todo: print/show error
         this._idle = requestIdleCallback((dd) => {
             while (dd.timeRemaining() > 0 && this.hasPendingEvents && this._idle !== null)
-                this.updateGatesNext();
+                this._updateGatesNext();
             if (this._idle !== null) {
                 if (!this.hasPendingEvents) {
                     this._idle = null;
@@ -103,9 +103,9 @@ export class Circuit extends HeadlessCircuit {
         });
     }
     displayOn(elem) {
-        return this.makePaper(elem, this._graph);
+        return this._makePaper(elem, this._graph);
     }
-    makePaper(elem, graph, opts) {
+    _makePaper(elem, graph, opts) {
         const circuit = this;
         opts = opts || {};
         const paper = new joint.dia.Paper({
@@ -133,7 +133,7 @@ export class Circuit extends HeadlessCircuit {
                 args: { radius: 10 }
             },
             cellViewNamespace: this._cells,
-            validateConnection: function(vs, ms, vt, mt, e, vl) {
+            validateConnection(vs, ms, vt, mt, e, vl) {
                 if (e === 'target') {
                     if (!mt) return false;
                     const pt = vt.model.getPort(vt.findAttribute('port', mt));
@@ -165,10 +165,10 @@ export class Circuit extends HeadlessCircuit {
                 edgeSep: 0,
                 rankSep: 110,
                 rankDir: "LR",
-                setPosition: function(element, position) {
+                setPosition(element, position) {
                     element.setLayoutPosition(position);
                 },
-                exportElement: function(element) {
+                exportElement(element) {
                     return element.getLayoutSize();
                 },
                 dagre: dagre,
@@ -194,7 +194,7 @@ export class Circuit extends HeadlessCircuit {
             }).appendTo('html > body');
             const pdiv = $('<div>').appendTo(div);
             const graph = model.get('graph');
-            const paper = this.makePaper(pdiv, graph);
+            const paper = this._makePaper(pdiv, graph);
             paper.once('render:done', function() {
                 circuit._windowCallback('Subcircuit', div, () => {
                     paper.remove();

--- a/tests/index.test.mjs
+++ b/tests/index.test.mjs
@@ -125,8 +125,8 @@ class SingleCellTestFixture {
             for (const [name, value] of Object.entries(ins)) {
                 this.circuit.setInput(name, value);
             }
-            this.circuit.updateGates(); // propagate input change
-            this.circuit.updateGates(); // propagate gate delay
+            this.circuit._updateGates(); // propagate input change
+            this.circuit._updateGates(); // propagate gate delay
             expect(this.circuit.hasPendingEvents).toBeFalsy();
             for (const k in this.outlist) {
                 expect(this.circuit.getOutput(this.outlist[k].name).toBin())


### PR DESCRIPTION
Also use new function syntax consistently.
This refactor has been tested with `npm run test` and (manually) by inspecting the examples.

Closes #33 