### PR TITLE
Support for importing digitaljs module to nodejs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /dist
 /node_modules
+/lib
 *.swp

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,13 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": true
+        },
+        "modules": "cjs"
+      }
+    ]
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,267 @@
       "resolved": "https://registry.npmjs.org/3vl/-/3vl-0.3.4.tgz",
       "integrity": "sha512-q4ctIYwgAUFV8sdFBuVx6yMhoQo/kS9sYoi3CacvWLEcynvseDMWMm0NjlSsnZDXiHQcP3kJNKYTjJGaLrrtMg=="
     },
+    "@babel/cli": {
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.11.6.tgz",
+      "integrity": "sha512-+w7BZCvkewSmaRM6H4L2QM3RL90teqEIHDIFXAmrW33+0jhlymnDAEdqVeCZATvxhQuio1ifoGVlJJbIiH9Ffg==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^2.1.8",
+        "commander": "^4.0.1",
+        "convert-source-map": "^1.1.0",
+        "fs-readdir-recursive": "^1.1.0",
+        "glob": "^7.0.0",
+        "lodash": "^4.17.19",
+        "make-dir": "^2.1.0",
+        "slash": "^2.0.0",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          },
+          "dependencies": {
+            "normalize-path": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            }
+          }
+        },
+        "binary-extensions": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+          "dev": true,
+          "optional": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "chokidar": {
+          "version": "2.1.8",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+          "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
+          }
+        },
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "dev": true,
+          "optional": true
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+          "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        },
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
@@ -5144,6 +5405,12 @@
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
       }
+    },
+    "fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -2,18 +2,29 @@
   "name": "digitaljs",
   "version": "0.6.6",
   "description": "Digital logic simulator",
-  "main": "src/index.mjs",
+  "main": "lib/circuit.js",
+  "browser": "src/index.mjs",
+  "exports": {
+    "node": {
+      "import": "./src/circuit.mjs",
+      "require": "./lib/circuit.js"
+    },
+    "browser": "src/index.mjs",
+    "default": "./lib/circuit.js"
+  },
   "scripts": {
-    "prepare": "npm run prod",
+    "prepare": "npm run prod && npm build-lib",
     "dev": "webpack --mode development",
     "prod": "webpack --mode production",
     "watch": "webpack --mode development --watch",
     "test": "jest",
+    "build-lib": "mkdir -p lib && babel src -d lib",
     "gh-pages": "webpack --mode production && gh-pages -a -d dist"
   },
   "author": "Marek Materzok",
   "license": "BSD-2-Clause",
   "devDependencies": {
+    "@babel/cli": "^7.10.2",
     "@babel/core": "^7.10.2",
     "@babel/preset-env": "^7.10.2",
     "acorn": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "browser": "src/index.mjs",
   "exports": {
     "node": {
-      "import": "./src/circuit.mjs",
-      "require": "./lib/circuit.js"
+      "import": "src/circuit.mjs",
+      "require": "lib/circuit.js"
     },
     "browser": "src/index.mjs",
-    "default": "./lib/circuit.js"
+    "default": "lib/circuit.js"
   },
   "scripts": {
     "prepare": "npm run prod && npm build-lib",

--- a/src/cells.mjs
+++ b/src/cells.mjs
@@ -1,13 +1,13 @@
 "use strict";
 
-export * from "./cells/base.mjs";
-export * from "./cells/io.mjs";
-export * from "./cells/gates.mjs";
-export * from "./cells/arith.mjs";
-export * from "./cells/bus.mjs";
-export * from "./cells/subcircuit.mjs";
-export * from "./cells/mux.mjs";
-export * from "./cells/dff.mjs";
-export * from "./cells/memory.mjs";
-export * from "./cells/fsm.mjs";
+export * from "./cells/base";
+export * from "./cells/io";
+export * from "./cells/gates";
+export * from "./cells/arith";
+export * from "./cells/bus";
+export * from "./cells/subcircuit";
+export * from "./cells/mux";
+export * from "./cells/dff";
+export * from "./cells/memory";
+export * from "./cells/fsm";
 

--- a/src/cells/arith.mjs
+++ b/src/cells/arith.mjs
@@ -3,7 +3,7 @@
 import * as joint from 'jointjs';
 import { Gate, GateView } from './base';
 import bigInt from 'big-integer';
-import * as help from '../help.mjs';
+import * as help from '../help';
 import { Vector3vl } from '3vl';
 
 // base class for arithmetic operations displayed with a circle

--- a/src/cells/bus.mjs
+++ b/src/cells/bus.mjs
@@ -3,7 +3,7 @@
 import * as joint from 'jointjs';
 import { Box, BoxView } from './base';
 import bigInt from 'big-integer';
-import * as help from '../help.mjs';
+import * as help from '../help';
 import { Vector3vl } from '3vl';
 
 // Bit extending

--- a/src/cells/dff.mjs
+++ b/src/cells/dff.mjs
@@ -3,7 +3,7 @@
 import * as joint from 'jointjs';
 import { Box, BoxView } from './base';
 import bigInt from 'big-integer';
-import * as help from '../help.mjs';
+import * as help from '../help';
 import { Vector3vl } from '3vl';
 
 // D flip-flops

--- a/src/cells/fsm.mjs
+++ b/src/cells/fsm.mjs
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import * as joint from 'jointjs';
 import { Box, BoxView } from './base';
 import bigInt from 'big-integer';
-import * as help from '../help.mjs';
+import * as help from '../help';
 import { Vector3vl, Mem3vl } from '3vl';
 import dagre from 'dagre';
 import graphlib from 'graphlib';

--- a/src/cells/gates.mjs
+++ b/src/cells/gates.mjs
@@ -3,7 +3,7 @@
 import * as joint from 'jointjs';
 import { Gate, GateView } from './base';
 import bigInt from 'big-integer';
-import * as help from '../help.mjs';
+import * as help from '../help';
 import { Vector3vl } from '3vl';
 
 const and_path = "M19 4v32h16c9 0 16-7 16-16S44 4 35 4H20z";

--- a/src/cells/memory.mjs
+++ b/src/cells/memory.mjs
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import * as joint from 'jointjs';
 import { Box, BoxView } from './base';
 import bigInt from 'big-integer';
-import * as help from '../help.mjs';
+import * as help from '../help';
 import { Vector3vl, Mem3vl } from '3vl';
 
 // Memory cell

--- a/src/cells/mux.mjs
+++ b/src/cells/mux.mjs
@@ -4,7 +4,7 @@ import * as joint from 'jointjs';
 import _ from 'lodash';
 import { Gate, GateView, portGroupAttrs } from './base';
 import bigInt from 'big-integer';
-import * as help from '../help.mjs';
+import * as help from '../help';
 import { Vector3vl } from '3vl';
 
 // Multiplexers

--- a/src/cells/subcircuit.mjs
+++ b/src/cells/subcircuit.mjs
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import { Box, BoxView } from './base';
 import { IO, Input, Output } from './io';
 import bigInt from 'big-integer';
-import * as help from '../help.mjs';
+import * as help from '../help';
 
 // Subcircuit model -- embeds a circuit graph in an element
 export const Subcircuit = Box.define('Subcircuit', {

--- a/src/circuit.mjs
+++ b/src/circuit.mjs
@@ -4,9 +4,9 @@ import * as joint from 'jointjs';
 import _ from 'lodash';
 import Backbone from 'backbone';
 import { Vector3vl, Display3vl } from '3vl';
-import * as cells from './cells.mjs';
+import * as cells from './cells';
 import FastPriorityQueue from 'fastpriorityqueue';
-import * as help from './help.mjs';
+import * as help from './help';
     
 export function getCellType(tp) {
     const types = {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -10,10 +10,10 @@ import Backbone from 'backbone';
 import { Vector3vl } from '3vl';
 import 'jquery-ui/ui/widgets/dialog';
 import 'jquery-ui/themes/base/all.css';
-import * as cells from './cells.mjs';
-import { HeadlessCircuit, getCellType } from './circuit.mjs';
-import { MonitorView, Monitor } from './monitor.mjs';
-import { IOPanelView } from './iopanel.mjs';
+import * as cells from './cells';
+import { HeadlessCircuit, getCellType } from './circuit';
+import { MonitorView, Monitor } from './monitor';
+import { IOPanelView } from './iopanel';
 import './style.css';
 
 // polyfill ResizeObserver for e.g. Firefox ESR 68.8

--- a/src/iopanel.mjs
+++ b/src/iopanel.mjs
@@ -4,8 +4,8 @@ import joint from 'jointjs';
 import _ from 'lodash';
 import $ from 'jquery';
 import Backbone from 'backbone';
-import * as help from './help.mjs';
-import * as cells from './cells.mjs';
+import * as help from './help';
+import * as cells from './cells';
 import { Vector3vl } from '3vl';
 
 let uniq_cntr = 0;

--- a/src/monitor.mjs
+++ b/src/monitor.mjs
@@ -4,7 +4,7 @@ import joint from 'jointjs';
 import _ from 'lodash';
 import $ from 'jquery';
 import Backbone from 'backbone';
-import * as help from './help.mjs';
+import * as help from './help';
 import { Vector3vl } from '3vl';
 import { Waveform, drawWaveform, defaultSettings, extendSettings, calcGridStep } from 'wavecanvas';
 import ResizeObserver from 'resize-observer-polyfill';


### PR DESCRIPTION
Changes include:
* Removing extension from local imports - allows 'require' to work after transpiling (mjs files become js files)
* Babel config for node target
* package.json changes:

    * Change main to lib/circuit.js - for importing in nodejs
    * Set browser field to previous main - for importing with bundler
    * Export field to support importing ES6 modules in nodejs via [Conditional imports](https://nodejs.org/api/packages.html#packages_conditional_exports)
