### PR TITLE
Bugfix: Conditional exports paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "browser": "src/index.mjs",
   "exports": {
     "node": {
-      "import": "src/circuit.mjs",
-      "require": "lib/circuit.js"
+      "import": "./src/circuit.mjs",
+      "require": "./lib/circuit.js"
     },
-    "browser": "src/index.mjs",
-    "default": "lib/circuit.js"
+    "browser": "./src/index.mjs",
+    "default": "./lib/circuit.js"
   },
   "scripts": {
     "prepare": "npm run prod && npm run build-lib",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "digitaljs",
   "version": "0.6.6",
   "description": "Digital logic simulator",
-  "main": "lib/circuit.js",
-  "browser": "src/index.mjs",
+  "main": "./lib/circuit.js",
+  "browser": "./src/index.mjs",
   "exports": {
     "node": {
       "import": "./src/circuit.mjs",


### PR DESCRIPTION
Although its not specified in documentation, nodejs complains about conditional exports paths that do not start with "./" and refuses to import package. Changed main and browser paths for consistency.