### PR TITLE
Combine different io types

### DIFF
--- a/examples/gates.json
+++ b/examples/gates.json
@@ -241,50 +241,36 @@
       "type": "Clock"
     },
     "044f875f-1926-4911-8336-5d91ad3edf67": {
-      "label": "Button",
+      "label": "1-bit input (Button)",
       "position": {
         "x": 800,
         "y": 200
       },
-      "type": "Button"
+      "type": "Input"
     },
     "5cb2f869-4852-4447-b4cd-fdcd01442c93": {
-      "label": "Lamp",
+      "label": "1-bit output (Lamp)",
       "position": {
         "x": 800,
         "y": 300
       },
-      "type": "Lamp"
+      "type": "Output"
     },
     "d81f4f5f-16dd-4fae-954d-db6666e070ac": {
-      "label": "NumEntry",
+      "label": "4-bit input (NumEntry)",
+      "bits": 4,
       "position": {
         "x": 800,
         "y": 400
       },
-      "type": "NumEntry"
+      "type": "Input"
     },
     "383468e5-fb2f-47a1-8beb-87df81cf9916": {
-      "label": "NumDisplay",
+      "label": "4-bit output (NumDisplay)",
+      "bits": 4,
       "position": {
         "x": 800,
         "y": 500
-      },
-      "type": "NumDisplay"
-    },
-    "30bc9df9-69e9-41e3-b230-3d999dc48330": {
-      "label": "Input",
-      "position": {
-        "x": 800,
-        "y": 600
-      },
-      "type": "Input"
-    },
-    "469d38ad-9177-433c-ab62-9d82f914fc1a": {
-      "label": "Output",
-      "position": {
-        "x": 800,
-        "y": 700
       },
       "type": "Output"
     },

--- a/examples/io.json
+++ b/examples/io.json
@@ -1,0 +1,119 @@
+{
+  "devices": {
+    "inSingle": {
+      "label": "1-bit input",
+      "bits": 1,
+      "type": "Input"
+    },
+    "inBus": {
+      "label": "4-bit input",
+      "bits": 4,
+      "type": "Input"
+    },
+    "outSingle": {
+      "label": "1-bit output",
+      "bits": 1,
+      "type": "Output"
+    },
+    "outBus": {
+      "label": "4-bit output",
+      "bits": 4,
+      "type": "Output"
+    },
+    "subcir": {
+      "label": "Subcircuit with I/O",
+      "type": "Subcircuit",
+      "celltype": "pipes"
+    }
+  },
+  "connectors": [
+    {
+      "from": {
+        "id": "inSingle",
+        "port": "out"
+      },
+      "to": {
+        "id": "subcir",
+        "port": "i1"
+      }
+    },
+    {
+      "from": {
+        "id": "inBus",
+        "port": "out"
+      },
+      "to": {
+        "id": "subcir",
+        "port": "i4"
+      }
+    },
+    {
+      "from": {
+        "id": "subcir",
+        "port": "o1"
+      },
+      "to": {
+        "id": "outSingle",
+        "port": "in"
+      }
+    },
+    {
+      "from": {
+        "id": "subcir",
+        "port": "o4"
+      },
+      "to": {
+        "id": "outBus",
+        "port": "in"
+      }
+    }
+  ],
+  "subcircuits": {
+    "pipes": {
+      "devices": {
+        "inSingle": {
+          "type": "Input",
+          "bits": 1,
+          "net": "i1"
+        },
+        "inBus": {
+          "type": "Input",
+          "bits": 4,
+          "net": "i4"
+        },
+        "outSingle": {
+          "type": "Output",
+          "bits": 1,
+          "net": "o1"
+        },
+        "outBus": {
+          "type": "Output",
+          "bits": 4,
+          "net": "o4"
+        }
+      },
+      "connectors": [
+        {
+          "from": {
+            "id": "inSingle",
+            "port": "out"
+          },
+          "to": {
+            "id": "outSingle",
+            "port": "in"
+          }
+        },
+        {
+          "from": {
+            "id": "inBus",
+            "port": "out"
+          },
+          "to": {
+            "id": "outBus",
+            "port": "in"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/cells/base.mjs
+++ b/src/cells/base.mjs
@@ -767,9 +767,9 @@ export const Box = Gate.define('Box', {
 export const BoxView = GateView.extend({
     _autoResizeBox: false,
     render() {
+        //todo: resize Box after port label / IO name / mode / bit size change
         GateView.prototype.render.apply(this, arguments);
-        if (this._autoResizeBox) {
-            if (this.model.get('box_resized')) return;
+        if (this._autoResizeBox && !this.model.get('box_resized')) {
             this.model.set('box_resized', true);
             this.model.prop('size/width', this._calculateBoxWidth());
         }

--- a/src/cells/subcircuit.mjs
+++ b/src/cells/subcircuit.mjs
@@ -68,8 +68,8 @@ export const Subcircuit = Box.define('Subcircuit', {
         Box.prototype._setInput.apply(this, arguments);
         const iomap = this.get('circuitIOmap');
         const input = this.get('graph').getCell(iomap[port]);
-        console.assert(input.setLogicValue);
-        input.setLogicValue(sig);
+        console.assert(input.isInput);
+        input._setInput(sig);
     },
     _setOutput(sig, port) {
         const signals = _.clone(this.get('outputSignals'));

--- a/src/iopanel.mjs
+++ b/src/iopanel.mjs
@@ -42,8 +42,8 @@ export class IOPanelView extends Backbone.View {
         return 'iopanel-' + text + '-' + this._idnum;
     }
     _handleAdd(cell) {
-        if (cell.setLogicValue) this._handleAddInput(cell);
-        else if (cell.getLogicValue) this.handleAddOutput(cell);
+        if (cell.isInput) this._handleAddInput(cell);
+        else if (cell.isOutput) this.handleAddOutput(cell);
     }
     _addLabel(row, cell) {
         const label = $(this._labelMarkup)
@@ -62,13 +62,13 @@ export class IOPanelView extends Backbone.View {
         this._addLabelFor(row, cell);
         const col = $(this._colMarkup)
             .appendTo(row);
-        if (cell.get('bits') == 1) {
+        if (cell.get('mode') == 1) {
             const ui = $(this._buttonMarkup)
                 .appendTo(col);
             const inp = ui.find('input').addBack('input')
                 .attr('id', this._id(cell.id))
                 .on('click', (evt) => {
-                    cell.setLogicValue(Vector3vl.fromBool(evt.target.checked));
+                    cell.setInput(Vector3vl.fromBool(evt.target.checked));
                 });
             const updater = (cell, sigs) => {
                 inp.prop("checked", sigs.out.isHigh);
@@ -89,7 +89,7 @@ export class IOPanelView extends Backbone.View {
                 .prop('pattern', display3vl.pattern(base))
                 .on('change', (e) => {
                     if (!display3vl.validate(base, e.target.value, bits)) return;
-                    cell.setLogicValue(display3vl.read(base, e.target.value, bits));
+                    cell.setInput(display3vl.read(base, e.target.value, bits));
                 });
             const updater = (cell, sigs) => {
                 ui.val(display3vl.show(base, sigs.out));
@@ -119,7 +119,7 @@ export class IOPanelView extends Backbone.View {
             const inp = ui.find('input').addBack('input')
                 .prop('disabled', true);
             const updater = (cell, sigs) => {
-                const val = cell.getLogicValue();
+                const val = cell.getOutput();
                 inp.prop("checked", val.isHigh);
                 inp.prop("indeterminate", !val.isDefined);
             };
@@ -138,7 +138,7 @@ export class IOPanelView extends Backbone.View {
 //                .prop('maxlength', sz)
 //                .prop('pattern', display3vl.pattern(base));
             const updater = (cell, sigs) => {
-                const val = cell.getLogicValue();
+                const val = cell.getOutput();
                 ui.val(display3vl.show(base, val));
             };
             this.listenTo(cell, 'change:inputSignals', updater);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,7 @@ const tests = [
     {name: 'ram', title: 'Simple RAM'},
     {name: 'fsm', title: 'Finite State Machine'},
     {name: 'gates', title: 'All available gates'},
+    {name: 'io', title: 'Input/Output types'},
     {name: 'horner', title: 'Benchmark example'},
     {name: 'warnings', title: 'Warnings example'}
 ];


### PR DESCRIPTION
As discussed in #35, this PR combines the three different input (Button/NumEntry/Input) and output (Lamp/NumDisplay/Output) types for better portability.

Things to consider:
- Boxes get currently only resized once upon initialization, not after manually changing e.g. bit width. As this same problem exists e.g. after renaming ports inside subcircuits, I would prefer working on this logic in a separate PR.
- For the Input/Output gates to know whether they are inside a subcircuit or not, the `subcircuit` property is already set on the (subcircuit) graph before adding the (subcircuit) gates. This will be most likely be refactored when working on #34 .
- The "public API" was slightly changed for `Input` and `Output` gates, the key methods are now called `setInput` and `getOutput` instead of `set`/`getLogicValue`, and a new property `isInput`/`isOutput` has been added for better comprehensibility.
- Backwards-compatibility is enabled by exporting the old io types as aliases to the new `Input`/`Output` gates.
- I've added a new example highlighting the different IO gates.

Closes #35 .