### PR TITLE
Bugfix: foreignObject placement in WebKit (e.g. Safari)

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -140,7 +140,7 @@ body {
     background-color: transparent;
     display: block;
     margin: 0;
-    position: relative;
+    position: fixed;
     width: 100%;
     height: 100%;
     cursor: initial;


### PR DESCRIPTION
WebKit is the browser engine used by Safari and e.g. Midori on Linux. The issue is also present in the deployed version. I tested the change on WebKit, Chromium and Firefox, where it worked as expected.

I used the first answer from https://stackoverflow.com/questions/51313873/svg-foreignobject-not-working-properly-on-safari.

Before:
![before](https://user-images.githubusercontent.com/18088991/119132659-43e74980-ba3b-11eb-99aa-c95ab99ef803.png)

After:
![after](https://user-images.githubusercontent.com/18088991/119132667-48136700-ba3b-11eb-9b16-a06f85945c46.png)
