### PR TITLE
Layout edges using elsjs

### DIFF
--- a/src/cells/mux.mjs
+++ b/src/cells/mux.mjs
@@ -6,6 +6,10 @@ import { Gate, GateView, portGroupAttrs } from './base.mjs';
 import * as help from '../help.mjs';
 import { Vector3vl } from '3vl';
 
+// add offset of 30pt to account for the top selection port and oversized box at layout time
+const mux_pos_offset = 20;
+const mux_size_offset = 30;
+
 // Multiplexers
 export const GenMux = Gate.define('GenMux', {
     /* default properties */
@@ -69,17 +73,25 @@ export const GenMux = Gate.define('GenMux', {
         if (i === undefined) return { out: Vector3vl.xes(this.get('bits').in) };
         return { out: data['in' + i] };
     },
-    //add offset of 30pt to account for the top selection port and oversized box at layout time
     getLayoutSize() {
         const size = this.size();
-        size.height += 30;
+        size.height += mux_size_offset;
         return size;
     },
     setLayoutPosition(position) {
         this.set('position', {
             x: position.x,
-            y: position.y + 20
+            y: position.y + mux_pos_offset
         });
+    },
+    getPortsPositions() {
+        const positions = Gate.prototype.getPortsPositions.apply(this, arguments);
+        const res = {};
+        for (const id in positions) {
+            res[id] = { ...positions[id] };
+            res[id].y = res[id].y + mux_pos_offset;
+        }
+        return res;
     },
     markup: Gate.prototype.markup.concat([{
             tagName: 'polygon',

--- a/src/cells/subcircuit.mjs
+++ b/src/cells/subcircuit.mjs
@@ -6,6 +6,10 @@ import { Box, BoxView } from './base.mjs';
 import { IO, Input, Output } from './io.mjs';
 import * as help from '../help.mjs';
 
+// add offset of 10pt to account for the top label at layout time
+const subcircuit_pos_offset = 10;
+const subcircuit_size_offset = 10;
+
 // Subcircuit model -- embeds a circuit graph in an element
 export const Subcircuit = Box.define('Subcircuit', {
     /* default properties */
@@ -68,17 +72,25 @@ export const Subcircuit = Box.define('Subcircuit', {
             return graph.getCell(iomap[port.id]).get('inputSignals').in;
         return Box.prototype._resetPortValue.call(this, port);
     },
-    //add offset of 10pt to account for the top label at layout time
     getLayoutSize() {
         const size = this.size();
-        size.height += 10;
+        size.height += subcircuit_size_offset;
         return size;
     },
     setLayoutPosition(position) {
         this.set('position', {
             x: position.x,
-            y: position.y + 10
+            y: position.y + subcircuit_pos_offset
         });
+    },
+    getPortsPositions() {
+        const positions = Box.prototype.getPortsPositions.apply(this, arguments);
+        const res = {};
+        for (const id in positions) {
+            res[id] = { ...positions[id] };
+            res[id].y = res[id].y + subcircuit_pos_offset;
+        }
+        return res;
     },
     markup: [{
             tagName: 'rect',


### PR DESCRIPTION
It seems that the sporeOverlap algorithm does not touch the edges causing them to overlap
with the nodes. Switching back to the layered algorithm fixes this.
The combination of orthogonal edge routing and nodePlacement.favorStraightEdges
creates a layout fairly similar to the old one.

I've tried a few different combination, the orthorgonal edge seems to be the easiest
to convert between elkjs and jointjs. Using polyline edges isn't too bad visually either
but the result from jointjs would not match what elkjs produces.

Fix tilk/digitaljs_online#26

Screenshot of layout for the circuit in the original issue:
![Screenshot_20211210_220601](https://user-images.githubusercontent.com/712232/145661698-a8b397a3-5696-4c67-9c3d-e4669002c893.png)

