### PR TITLE
Make sure circuits with constant ops can be serialized to JSON correctly

### DIFF
--- a/src/transform.mjs
+++ b/src/transform.mjs
@@ -91,7 +91,7 @@ export function integrateArithConstant(model, dev, id) {
         }
         newDev.leftOp = in1 == "in1";
         newDev.type = arith_constant.get(newDev.type);
-        newDev.constant = i;
+        newDev.constant = Number(i);
         model.removeDevice(id);
         const constOutConnList = Object.values(model.outputPortConnectors(inId, "out"));
         if (constOutConnList.length == 0)


### PR DESCRIPTION
The fix is limited to OpConst to make sure we can handle the deserialization without any problems. Also fixed the implementation of ShiftConst to handle BigInt produced by constant folding.

Add tests to check the validity and stability of the JSON object.

Fix #65

.... took me longer to add the tests than to fix the issue....