### PR TITLE
Disable submit action on IOPanel

### DIFF
--- a/src/iopanel.mjs
+++ b/src/iopanel.mjs
@@ -28,7 +28,8 @@ export class IOPanelView extends Backbone.View {
         this.listenTo(this.model, "display:add", () => { this.render() });
     }
     render() {
-        this.$el.html('<form>' + this._inputPanelMarkup + this._outputPanelMarkup + '</form>');
+        // Disable the default action of submission since it will usually cause a page refresh.
+        this.$el.html('<form onsubmit="return false">' + this._inputPanelMarkup + this._outputPanelMarkup + '</form>');
         for (const element of this.model.getInputCells())
             this._handleAddInput(element);
         for (const element of this.model.getOutputCells())


### PR DESCRIPTION
With a multi-bit input field, it is very tempting to apply the new value
by typing enter. Since it is in a form, this can trigger the default submission
action from the browser and causes the form to be submitted along with a page refresh.

Disable that by adding `onsubmit="return false"` to the form.