### PR TITLE
Improve touch support

### DIFF
--- a/src/cells/fsm.mjs
+++ b/src/cells/fsm.mjs
@@ -189,6 +189,7 @@ export const FSMView = BoxView.extend({
     events: {
         "click foreignObject.tooltip": "stopprop",
         "mousedown foreignObject.tooltip": "stopprop",
+        "touchstart foreignObject.tooltip": "stopprop", // make sure the input receives focus
         "click a.zoom": "_displayEditor"
     },
     _displayEditor(evt) {

--- a/src/cells/io.mjs
+++ b/src/cells/io.mjs
@@ -46,7 +46,8 @@ export const NumBaseView = BoxView.extend({
     _autoResizeBox: true,
     events: {
         "click select.numbase": "stopprop",
-        "mousedown select.numbase": "stopprop",
+        "mousedown select.numbase": "stopprop", // Prevent drag
+        "touchstart select.numbase": "stopprop", // Prevent drag & make sure select works
         "change select.numbase": "_changeNumbase"
     },
     _changeNumbase(evt) {
@@ -273,10 +274,12 @@ export const InputView = IOView.extend({
     events: _.merge({
         //button
         "click .btnface": "_onButton",
-        "mousedown .btnface": "stopprop",
+        "mousedown .btnface": "stopprop", // Prevent drag
+        "touchstart .btnface": "stopprop", // Prevent drag & make sure click is generated
         //numEntry
         "click input": "stopprop",
-        "mousedown input": "stopprop",
+        "mousedown input": "stopprop", // Prevent drag
+        "touchstart input": "stopprop", // Prevent drag & make sure the input receives focus
         "change input": "_onNumEntry"
     }, NumBaseView.prototype.events),
     _onButton() {
@@ -494,6 +497,7 @@ export const ClockView = BoxView.extend({
     events: {
         "click input": "stopprop",
         "mousedown input": "stopprop",
+        "touchstart input": "stopprop", // make sure the input receives focus
         "change input": "_changePropagation",
         "input input": "_changePropagation"
     },

--- a/src/cells/memory.mjs
+++ b/src/cells/memory.mjs
@@ -266,6 +266,7 @@ export const MemoryView = BoxView.extend({
     events: {
         "click foreignObject.tooltip": "stopprop",
         "mousedown foreignObject.tooltip": "stopprop",
+        "touchstart foreignObject.tooltip": "stopprop", // make sure the input receives focus
         "click a.zoom": "_displayEditor"
     },
     _displayEditor(evt) {

--- a/src/cells/subcircuit.mjs
+++ b/src/cells/subcircuit.mjs
@@ -137,6 +137,7 @@ export const SubcircuitView = BoxView.extend({
     events: {
         "click foreignObject.tooltip": "stopprop",
         "mousedown foreignObject.tooltip": "stopprop",
+        "touchstart foreignObject.tooltip": "stopprop", // make sure the input receives focus
         "click a.zoom": "zoomInCircuit"
     },
     zoomInCircuit(evt) {


### PR DESCRIPTION
Prevent touch start events from being handled by jointjs to make sure
that the native click and focus events are generated.

It is still too easy to move some of the components with touch input but this should at least
make it possible to use touch interface to interact with the circuit.

Using touch as clicking works on all the browser variants I've tested, including firefox and chromium on linux, firefox (safari) on ipad, firefox and chrome on android. Using touch as hover, however, doesn't seem to work on the android browsers but that's most likely a separate issue...