### PR TITLE
Save different instances of subcircuits separately

### DIFF
--- a/src/cells/subcircuit.mjs
+++ b/src/cells/subcircuit.mjs
@@ -28,7 +28,9 @@ export const Subcircuit = Box.define('Subcircuit', {
     }
 }, {
     initialize() {
-        this.bindAttrToProp('text.type/text', 'celltype');
+        if (!this.get('disp_celltype'))
+            this.set('disp_celltype', this.get('celltype'))
+        this.bindAttrToProp('text.type/text', 'disp_celltype');
         
         const graph = this.get('graph');
         console.assert(graph instanceof joint.dia.Graph);
@@ -102,7 +104,7 @@ export const Subcircuit = Box.define('Subcircuit', {
             selector: 'type'
         }
     ], Box.prototype.markupZoom),
-    _gateParams: Box.prototype._gateParams.concat(['celltype']),
+    _gateParams: Box.prototype._gateParams.concat(['celltype', 'disp_celltype']),
     _unsupportedPropChanges: Box.prototype._unsupportedPropChanges.concat(['celltype'])
 });
 

--- a/src/circuit.mjs
+++ b/src/circuit.mjs
@@ -292,8 +292,19 @@ export class HeadlessCircuit {
             for (const elem of graph.getElements()) {
                 const args = ret.devices[elem.get('id')] = elem.getGateParams(layout);
                 if (!laid_out) delete args.position;
-                if (elem instanceof this._cells.Subcircuit && !subcircuits[elem.get('celltype')]) {
-                    subcircuits[elem.get('celltype')] = fromGraph(elem.get('graph'));
+                if (elem instanceof this._cells.Subcircuit) {
+                    const celltype = elem.get('celltype');
+                    const subcircuit = {
+                        dev: args,
+                        graph: fromGraph(elem.get('graph'))
+                    };
+                    const prev_sub = subcircuits[celltype];
+                    if (!prev_sub) {
+                        subcircuits[celltype] = [subcircuit];
+                    }
+                    else {
+                        prev_sub.push(subcircuit);
+                    }
                 }
             }
             for (const elem of graph.getLinks()) {
@@ -302,7 +313,43 @@ export class HeadlessCircuit {
             return ret;
         }
         const ret = fromGraph(this._graph);
-        ret.subcircuits = subcircuits;
+        ret.subcircuits = {};
+        for (const celltype in subcircuits) {
+            const subs = subcircuits[celltype];
+            const nsubs = subs.length;
+            if (nsubs == 1) {
+                // We check for conflict of generated names with
+                // both the original names and the new names
+                // so it's guaranteed that none of the original names conflict
+                // with the generated names
+                console.assert(!(celltype in ret.subcircuits));
+                ret.subcircuits[celltype] = subs[0].graph;
+                continue;
+            }
+            let cnt = -1;
+            const gen_name = () => {
+                while (true) {
+                    const id = cnt++;
+                    // Use the original name for the first one to keep the file closer
+                    // to the old one.
+                    if (id == -1)
+                        return celltype;
+                    const name = `${celltype}$${id}`;
+                    if (name in subcircuits || name in ret.subcircuits)
+                        continue;
+                    return name;
+                }
+            };
+            for (let i = 0; i < nsubs; i++) {
+                const sub = subs[i];
+                // Rename, assign to return value, and fix the reference (celltype)
+                // in the device tree.
+                sub.dev.celltype = gen_name();
+                if (!sub.dev.disp_celltype && sub.dev.celltype !== celltype)
+                    sub.dev.disp_celltype = celltype;
+                ret.subcircuits[sub.dev.celltype] = sub.graph;
+            }
+        }
         return ret;
     }
     waitForWire(wire, trigger) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -162,7 +162,7 @@ export class Circuit extends HeadlessCircuit {
         // subcircuit display
         this.listenTo(paper, 'open:subcircuit', (model) => {
             const div = $('<div>', { 
-                title: model.get('celltype') + ' ' + model.get('label')
+                title: model.get('disp_celltype') + ' ' + model.get('label')
             }).appendTo('html > body');
             const pdiv = $('<div>').appendTo(div);
             const graph = model.get('graph');


### PR DESCRIPTION
while keeping the format backward compatible.

Although different instances of subcircuits starts identical,
they corresponds to distinct runtime object and their internal
may deviate from each other due to edits done on each subcircuits.

The current format discard all the changes except for the first subcircuit
and apply the edit on the first subcircuit to all instances during loading.

This change modifies the saving format while keeping the file backward compatible
so that the new file can still be opened by old code, with only minor display differences.
This is done by automatically generate new celltype for each instances of the subcircuit
on saving and saving the old value that is only useful for display in a separate attribute
`disp_celltype`. This automatic name generation is also only done when there are
multiple instances of the same cell type so that we can keep generating names shorter
and the file as closed to the old format as possible.

Make this a draft currently since there are a few things that can are up to debate.

1. If backward compatibility should be maintained. Personally I think it should be as much as possible. If backward compatibility is not to be maintained, this info can simply be saved into the devices and/or a diff version could be computed to save space, though I really don't think that's really necessary....
2. If I should try harder to not clone the subcircuits.

    This can be done either by saving a flag marking whether anything has changed since the loading, or to simply detect if the resulting object matches (or both). The marker could potentially be separate for layout vs not, and it'll almost certainly have false positives due to no-op/reverted changes. It's much more difficult to track changes accurately and it doesn't save any saving time to detect the differences after serialization so I'm not doing either right now....