### PR TITLE
Fix the lifetime of the event listeners for the sub-windows

### DIFF
--- a/src/cells/fsm.mjs
+++ b/src/cells/fsm.mjs
@@ -214,7 +214,7 @@ export const FSMView = BoxView.extend({
             graph.set('laid_out', true);
         }
         // auto-resizing
-        this.listenTo(graph, 'change:position', (elem) => {
+        paper.listenTo(graph, 'change:position', (elem) => {
             paper.fitToContent({ padding: 30, allowNewOrigin: 'any' });
         });
         paper.fitToContent({ padding: 30, allowNewOrigin: 'any' });


### PR DESCRIPTION
Previously, these listeners are bound to the lifetime of the views
that triggered the display of the sub-windows.
This causes the views to stop functioning once the triggering elements are destroyed,
e.g. when the sub-circuit view showing the element is closed.

Instead, we can either bind the lifetime of the listener to that of the new paper,
or manually disconnect them in the signal callback.
Also do some minor cleanup to make sure the callbacks do not refer to the parent object
and only to the model for the new sub-window.

Additionally, the closing callback for memory sub-window used to disconnect all listener
that are related to the MemoryView. With the change only the closed subwindow
is disconnected.

Fix #75