### PR TITLE
Use batch to mark the beginning and end of elkjs layout change

### DIFF
--- a/src/elkjs.mjs
+++ b/src/elkjs.mjs
@@ -62,6 +62,7 @@ function to_elkjs(graph) {
 }
 
 function from_elkjs(graph, elkGraph) {
+    graph.startBatch('layout');
     for (const child of elkGraph.children) {
         const cell = graph.getCell(child.id);
         cell.setLayoutPosition({
@@ -119,6 +120,7 @@ function from_elkjs(graph, elkGraph) {
         add_point(edge.sections[0].endPoint, true);
         graph.getCell(edge.id).vertices(vertices);
     }
+    graph.stopBatch('layout');
 }
 
 export function elk_layout(graph) {


### PR DESCRIPTION
This matches the behavior of the dagre layout engine
and allows the user to distinguish between automatic and user-induced layout-change events.

This is particularly important since elkjs layout happens asynchronously so simply treating events from the initial display of the circuit as automatic layout event doesn't work.