### PR TITLE
Add LUT cell

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ instance.
     * Transition descriptor attributes: `ctrl_in`, `ctrl_out` (binary strings), `state_in`, `state_out` (natural numbers)
     * Inputs: `clk` (1-bit), `arst` (1-bit), `in` (`bits.in`-bit)
     * Outputs: `out` (`bits.out`-bit)
+ * Lookup tables: `LUT`
+    * Attributes: `bits.in`, `bits.out`, `lut` (array of binary strings)
+    * Inputs: `in` (`bits.in`-bit)
+    * Outputs: `out` (`bits.out`-bit)
 
 # TODO
 

--- a/examples/lut.json
+++ b/examples/lut.json
@@ -1,0 +1,131 @@
+{
+  "devices": {
+    "dev0": {
+      "type": "Input",
+      "net": "a",
+      "order": 0,
+      "bits": 2
+    },
+    "dev1": {
+      "type": "Input",
+      "net": "b",
+      "order": 1,
+      "bits": 2
+    },
+    "dev2": {
+      "type": "Output",
+      "net": "result",
+      "order": 2,
+      "bits": 4
+    },
+    "dev3": {
+      "type": "LUT",
+      "bits": {
+        "in": 2,
+        "out": 1
+      },
+      "lut": [
+        "0",
+        "0",
+        "1",
+        "1"
+      ]
+    },
+    "dev4": {
+      "type": "LUT",
+      "bits": {
+        "in": 2,
+        "out": 1
+      },
+      "lut": [
+        "1",
+        "0",
+        "0",
+        "1"
+      ]
+    },
+    "dev5": {
+      "type": "LUT",
+      "bits": {
+        "in": 2,
+        "out": 4
+      },
+      "lut": [
+        "0000",
+        "0011",
+        "1100",
+        "1111"
+      ]
+    },
+    "dev6": {
+      "type": "BusGroup",
+      "groups": [
+        1,
+        1
+      ]
+    }
+  },
+  "connectors": [
+    {
+      "from": {
+        "id": "dev0",
+        "port": "out"
+      },
+      "to": {
+        "id": "dev3",
+        "port": "in"
+      }
+    },
+    {
+      "from": {
+        "id": "dev1",
+        "port": "out"
+      },
+      "to": {
+        "id": "dev4",
+        "port": "in"
+      }
+    },
+    {
+      "from": {
+        "id": "dev3",
+        "port": "out"
+      },
+      "to": {
+        "id": "dev6",
+        "port": "in1"
+      }
+    },
+    {
+      "from": {
+        "id": "dev4",
+        "port": "out"
+      },
+      "to": {
+        "id": "dev6",
+        "port": "in0"
+      }
+    },
+    {
+      "from": {
+        "id": "dev6",
+        "port": "out"
+      },
+      "to": {
+        "id": "dev5",
+        "port": "in"
+      }
+    },
+    {
+      "from": {
+        "id": "dev5",
+        "port": "out"
+      },
+      "to": {
+        "id": "dev2",
+        "port": "in"
+      }
+    }
+  ],
+  "subscircuits": {}
+}

--- a/src/cells.mjs
+++ b/src/cells.mjs
@@ -9,5 +9,6 @@ export * from "./cells/subcircuit.mjs";
 export * from "./cells/mux.mjs";
 export * from "./cells/dff.mjs";
 export * from "./cells/memory.mjs";
+export * from "./cells/lut.mjs";
 export * from "./cells/fsm.mjs";
 export * from "./cells/display7.mjs";

--- a/src/cells/lut.mjs
+++ b/src/cells/lut.mjs
@@ -1,0 +1,237 @@
+"use strict";
+
+import $ from 'jquery';
+import _ from 'lodash';
+import { Box, BoxView } from './base.mjs';
+import * as help from '../help.mjs';
+import { Vector3vl, Mem3vl } from '3vl';
+
+// LUT cell
+export const LUT = Box.define('LUT', {
+    /* default properties */
+    bits: {
+        in: 1,
+        out: 1
+    },
+
+    attrs: {
+        oper: {
+            refX: .5, refY: .5,
+            textAnchor: 'middle', textVerticalAnchor: 'middle',
+            fontSize: '8pt',
+            text: 'LUT'
+        }
+    },
+    ports: {
+        groups: {
+            'in': {
+                position: Box.prototype._getStackedPosition({ side: 'left' })
+            },
+            'out': {
+                position: Box.prototype._getStackedPosition({ side: 'right' })
+            }
+        }
+    }
+}, {
+    initialize() {
+        const bits = this.get('bits');
+        this.get('ports').items = [
+            { id: 'in', group: 'in', dir: 'in', bits: bits.in },
+            { id: 'out', group: 'out', dir: 'out', bits: bits.out }
+        ];
+
+        Box.prototype.initialize.apply(this, arguments);
+
+        this.on('change:bits', (_,bits) => {
+            this._setPortsBits(bits);
+        });
+
+        this.removeProp('lutdata'); // performance hack
+    },
+    prepare() {
+        const bits = this.get('bits');
+        const words = 1 << bits.in;
+        const lut = this.get('lut');
+        const lutdata = this.get('lutdata');
+
+        if (lutdata)
+            this.lutdata = Mem3vl.fromJSON(bits.out, lutdata);
+        else {
+            this.lutdata = new Mem3vl(bits.out, words);
+            if (lut) {
+                for (let i = 0; i < words; i++) {
+                    if (i < lut.length)
+                        this.lutdata.set(i, Vector3vl.fromBin(lut[i], bits.out));
+                }
+            }
+        }
+        console.assert(this.lutdata.words == words);
+    },
+    operation(data) {
+        const bits = this.get('bits');
+        const words = 1 << bits.in;
+        const valid_addr = n => n >= 0 && n < words;
+        const addr = data.in.isFullyDefined ? data.in.toNumber() : -1;
+        return {
+            out: valid_addr(addr) ? this.lutdata.get(addr) : Vector3vl.xes(bits.out)
+        };
+    },
+    markup: Box.prototype.markup.concat([{
+        tagName: 'text',
+        className: 'oper',
+        selector: 'oper'
+    }], Box.prototype.markupZoom),
+    getGateParams() {
+        // hack to get lutdata back
+        const params = Box.prototype.getGateParams.apply(this, arguments);
+        params.lutdata = this.lutdata.toJSON();
+        return params;
+    },
+    _gateParams: Box.prototype._gateParams.concat(['bits']),
+    _unsupportedPropChanges: Box.prototype._unsupportedPropChanges.concat(['bits'])
+});
+export const LUTView = BoxView.extend({
+    _autoResizeBox: true,
+    events: {
+        "click foreignObject.tooltip": "stopprop",
+        "mousedown foreignObject.tooltip": "stopprop",
+        "touchstart foreignObject.tooltip": "stopprop", // make sure the input receives focus
+        "click a.zoom": "_displayEditor"
+    },
+    _displayEditor(evt) {
+        evt.stopPropagation();
+        const model = this.model;
+        const display3vl = model.graph._display3vl;
+        const div = $('<div>', {
+            title: "LUT contents: " + model.get('label')
+        }).appendTo('html > body');
+        div.append($(
+            '<div class="btn-toolbar" role="toolbar">' +
+            '<div class="btn-group mr-2" role="group">' +
+            '<button name="prev" type="button" class="btn btn-secondary" title="Previous page">←</button>' +
+            '<button name="next" type="button" class="btn btn-secondary" title="Next page">→</button>' +
+            '</div>' +
+            '<div class="input-group">' +
+            help.baseSelectMarkupHTML(display3vl, model.get('bits'), 'hex') +
+            '</div>' +
+            '</div>' +
+            '<table class="memeditor">' +
+            '</table>'));
+        const bits = model.get('bits');
+        const words = 1 << bits.in;
+        const lutdata = model.lutdata;
+        const ahex = Math.ceil(bits.in / 4);
+        const rows = 8;
+        let columns, address = 0;
+        const get_numbase = () => div.find('select[name=base]').val();
+        const getCell = (addr) => {
+            const r = Math.floor((addr - address) / columns);
+            const c = addr - address - r * columns;
+            return div.find('table tr:nth-child('+(r+1)+') td:nth-child('+(c+2)+') input');
+        }
+        const clearMarkings = (sigs) => {
+            if (sigs.in.isFullyDefined)
+                getCell(sigs.in.toNumber()).removeClass('isread');
+        }
+        const displayMarkings = (sigs) => {
+            if (sigs.in.isFullyDefined)
+                getCell(sigs.in.toNumber()).addClass('isread');
+        }
+        const updateStuff = () => {
+            const numbase = get_numbase();
+            div.find('button[name=prev]').prop('disabled', address <= 0);
+            div.find('button[name=next]').prop('disabled', address + rows * columns >= words);
+            let row = div.find('table tr:first-child');
+            const lutdata = model.lutdata;
+            for (let r = 0; r < rows; r++, row = row.next()) {
+                if (address + r * columns >= words) break;
+                const addrs = (address + r * columns).toString(16);
+                let col = row.find('td:first-child');
+                col.text('0'.repeat(ahex - addrs.length) + addrs)
+                col = col.next();
+                for (let c = 0; c < columns; c++, col = col.next()) {
+                    if (address + r * columns + c >= words) break;
+                    col.find('input').val(display3vl.show(numbase, lutdata.get(address + r * columns + c)))
+                                     .removeClass('invalid');
+                }
+            }
+            displayMarkings(model.get('inputSignals'));
+        };
+        const redraw = () => {
+            const bits = model.get('bits');
+            const numbase = get_numbase();
+            const ptrn = display3vl.pattern(numbase);
+            const ds = display3vl.size(numbase, bits.out);
+            columns = Math.min(words, 16, Math.ceil(32 / ds));
+            address = Math.max(0, Math.min(words - rows * columns, address));
+            const table = div.find('table');
+            table.empty();
+            for (let r = 0; r < rows; r++) {
+                if (address + r * columns >= words) break;
+                const row = $('<tr>');
+                $('<td>').appendTo(row);
+                for (let c = 0; c < columns; c++) {
+                    if (address + r * columns + c >= words) break;
+                    const col = $('<td>');
+                    $('<input type="text">')
+                        .attr('size', ds)
+                        .attr('maxlength', ds)
+                        .attr('pattern', ptrn)
+                        .appendTo(col);
+                    col.appendTo(row);
+                }
+                row.appendTo(table);
+            }
+            updateStuff();
+        };
+        redraw();
+        div.find("select[name=base]").on('change', redraw);
+        div.find("button[name=prev]").on('click', () => {
+            clearMarkings(model.get('inputSignals'));
+            address = Math.max(0, address - rows * columns);
+            updateStuff();
+        });
+        div.find("button[name=next]").on('click', () => {
+            clearMarkings(model.get('inputSignals'));
+            address = Math.min(words - rows * columns, address + rows * columns);
+            updateStuff();
+        });
+        div.on("change", "input", (evt) => {
+            const numbase = get_numbase();
+            const target = $(evt.target);
+            const c = target.closest('td').index() - 1;
+            const r = target.closest('tr').index();
+            const addr = address + r * columns + c;
+            const bits = model.get('bits');
+            if (display3vl.validate(numbase, evt.target.value, bits.out)) {
+                const val = display3vl.read(numbase, evt.target.value, bits.out);
+                lutdata.set(addr, val);
+                model.trigger('manualLutChange', model, addr, val);
+                target.removeClass('invalid');
+            } else {
+                target.addClass('invalid');
+            }
+        });
+        const mem_change_cb = (addr, data) => {
+            if (addr < address || addr > address + rows * columns) return;
+            const numbase = get_numbase();
+            const z = getCell(addr)
+                .val(display3vl.show(numbase, lutdata.get(addr)))
+                .removeClass('invalid')
+                .removeClass('flash');
+            setTimeout(() => { z.addClass('flash') }, 10);
+        };
+        const input_change_cb = (gate, sigs) => {
+            clearMarkings(model.previous('inputSignals'));
+            displayMarkings(sigs);
+        };
+        model.on("memChange", mem_change_cb);
+        model.on("change:inputSignals", input_change_cb);
+        this.paper.trigger('open:memorycontent', div, () => {
+            div.remove();
+            model.off("memChange", mem_change_cb);
+            model.off("change:inputSignals", input_change_cb);
+        });
+        return false;
+    }
+});

--- a/src/circuit.mjs
+++ b/src/circuit.mjs
@@ -52,6 +52,7 @@ export function getCellType(tp) {
         '$pmux': cells.Mux1Hot,
         '$dff': cells.Dff,
         '$mem': cells.Memory,
+        '$lut': cells.LUT,
         '$fsm': cells.FSM,
         '$clock': cells.Clock,
         '$button': cells.Button,

--- a/src/engines/synch.mjs
+++ b/src/engines/synch.mjs
@@ -45,6 +45,9 @@ export class SynchEngine extends BaseEngine {
         this.listenTo(graph, 'manualMemChange', (gate) => {
             this._enqueue(gate);
         });
+        this.listenTo(graph, 'manualLutChange', (gate) => {
+            this._enqueue(gate);
+        });
         this.listenTo(graph, 'change:constantCache', (gate) => {
             this._enqueue(gate);
         });

--- a/src/engines/worker-worker.mjs
+++ b/src/engines/worker-worker.mjs
@@ -310,6 +310,11 @@ class WorkerEngineWorker {
         gate.memdata.set(addr, Vector3vl.fromClonable(data));
         this._enqueue(gate);
     }
+    manualLutChange(graphId, gateId, addr, data) {
+        const gate = this._graphs[graphId].getGate(gateId);
+        gate.lutdata.set(addr, Vector3vl.fromClonable(data));
+        this._enqueue(gate);
+    }
     monitor(graphId, gateId, port, monitorId, {triggerValues, stopOnTrigger, oneShot, synchronous }) {
         if (triggerValues != undefined)
             for (const k of triggerValues.keys())

--- a/src/engines/worker.mjs
+++ b/src/engines/worker.mjs
@@ -51,6 +51,11 @@ export class WorkerEngine extends BaseEngine {
                 this._worker.postMessage({ type: 'manualMemChange', args: [gate.graph.cid, gate.id, addr, data] });
             });
         }
+        if (gate instanceof cells.LUT) {
+            this.listenTo(gate, 'manualLutChange', (gate, addr, data) => {
+                this._worker.postMessage({ type: 'manualLutChange', args: [gate.graph.cid, gate.id, addr, data] });
+            });
+        }
         for (const paramName of gate._gateParams) {
             if (gate._unsupportedPropChanges.includes(paramName) || gate._presentationParams.includes(paramName))
                 continue;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ const tests = [
     {name: 'rom', title: 'Async ROM'},
     {name: 'ram', title: 'Simple RAM'},
     {name: 'fsm', title: 'Finite State Machine'},
+    {name: 'lut', title: 'Lookup Tables (LUTs)'},
     {name: 'gates', title: 'All available gates'},
     {name: 'biggate', title: 'N-ary gates'},
     {name: 'muxsparse', title: 'Sparse mux'},


### PR DESCRIPTION
Add support for lookup tables of arbitrary input and output sizes. The LUT cell is based on the memory cell, but with less complexity. This PR is accompanied by [this PR] in yosys2digitaljs.

**Motivation**
We use DigitalJS and yosys2digitaljs for visualising FPGA synthesis in our [EDAcation project](https://github.com/EDAcation). For one of our visualisations, Yosys outputs LUTs, so we would like to support these in DigitalJS. Yosys only exports n-bit to 1-bit LUTs in our experience, but I implemented the LUT as generally as possible for DigitalJS.

**Example**
![Screenshot from 2022-09-16 14-33-15](https://user-images.githubusercontent.com/7486186/190639565-ed1b480a-421b-43c8-ba68-56e2b3872b9d.png)
