### PR TITLE
Allow customization of cell attributes

### DIFF
--- a/src/cells/base.mjs
+++ b/src/cells/base.mjs
@@ -114,6 +114,18 @@ export const Gate = joint.shapes.basic.Generic.define('Gate', {
         this.attr(attr, this.get(prop));
         this.on('change:' + prop, (_, val) => this.attr(attr, val));
     },
+    setAttrs(attrs, path) {
+        path = path ?? [];
+
+        for (const [attrName, val] of Object.entries(attrs)) {
+            const attrPath = path.concat(attrName);
+            if (typeof val === 'object') {
+                this.setAttrs(val, attrPath);
+            } else {
+                this.attr(attrPath.join('/'), val);
+            }
+        }
+    },
   
     /*
      * Private methods.

--- a/src/circuit.mjs
+++ b/src/circuit.mjs
@@ -72,8 +72,9 @@ export function getCellType(tp) {
 }
         
 export class HeadlessCircuit {
-    constructor(data, {cellsNamespace = {}, engine = SynchEngine, engineOptions = {}} = {}) {
+    constructor(data, {cellsNamespace = {}, engine = SynchEngine, engineOptions = {}, cellAttributes = {}} = {}) {
         this._cells = Object.assign(cells, cellsNamespace);
+        this._cellAttributes = cellAttributes;
         this._display3vl = new Display3vl();
         this._display3vl.addDisplay(new help.Display3vlASCII());
         this._graph = this._makeGraph(data, data.subcircuits);
@@ -164,6 +165,10 @@ export class HeadlessCircuit {
             if (cellType == this._cells.Subcircuit)
                 cellArgs.graph = this._makeGraph(subcircuits[dev.celltype], subcircuits, { nested: true });
             const cell = new cellType(cellArgs);
+            const cellAttrs = this._cellAttributes[cell.get('type')];
+            if (cellAttrs) {
+                cell.setAttrs(cellAttrs);
+            }
             graph.addCell(cell);
         }
         for (const conn of data.connectors) {


### PR DESCRIPTION
Exposes a new constructor argument to `HeadlessCircuit` that allows customization of attributes for specific cells. These attributes extend or overwrite the attributes that are set by default for the various models.

As an example, the below code would make the fill color for all `And` gates light green:
```js
const cellAttrs = {
    'And': {
        'body': {'fill': 'lightgreen'}
    }
}

const circuit = new digitaljs.Circuit(input, {cellAttributes: cellAttrs});
```

A current limitation of this feature is that it relies on the types as passed to the JointJS cells, which makes it more difficult to specify the attributes for specific Yosys prims (e.g. `And` instead of `$and`). It would be possible to split off the current lookup table used in `getCellType`, but another solution (which I would prefer) is to convert the current `.define('type', ...)` structures into proper class inheritance, similar to what the tutorial does [here](https://resources.jointjs.com/tutorial/cell-namespace). That would allow users to get the type using `getCellType(...).type`, and even allow getting rid of that lookup table altogether by making the Yosys primitive a static field on the models.

Let me know what you think 🙂 